### PR TITLE
Update V4-CSDL-to-OpenAPI.xsl

### DIFF
--- a/tools/V4-CSDL-to-OpenAPI.xsl
+++ b/tools/V4-CSDL-to-OpenAPI.xsl
@@ -42,6 +42,7 @@
   <xsl:param name="scheme" select="'http'" />
   <xsl:param name="host" select="'localhost'" />
   <xsl:param name="basePath" select="'/service-root'" />
+  <xsl:param name="basePathInPathTemplate" select="false()" />
 
   <xsl:param name="info-title" select="null" />
   <xsl:param name="info-description" select="null" />
@@ -1620,7 +1621,9 @@
     <xsl:variable name="entityType" select="//edm:Schema[@Namespace=$namespace]/edm:EntityType[@Name=$type]" />
 
     <xsl:text>"</xsl:text>
-    <xsl:value-of select="$basePath" />
+    <xsl:if test="$basePathInPathTemplate">
+      <xsl:value-of select="$basePath" />
+    </xsl:if>
     <xsl:text>/</xsl:text>
     <xsl:if test="$childtype=@Name">
       <xsl:value-of select="$parenttype" />
@@ -2072,7 +2075,9 @@
 
     <!-- entity path template -->
     <xsl:text>,"</xsl:text>
-    <xsl:value-of select="$basePath" />
+    <xsl:if test="$basePathInPathTemplate">
+      <xsl:value-of select="$basePath" />
+    </xsl:if>
     <xsl:text>/</xsl:text>
     <xsl:if test="$childtype=@Name">
       <xsl:value-of select="$parenttype" />

--- a/tools/V4-CSDL-to-OpenAPI.xsl
+++ b/tools/V4-CSDL-to-OpenAPI.xsl
@@ -42,7 +42,7 @@
   <xsl:param name="scheme" select="'http'" />
   <xsl:param name="host" select="'localhost'" />
   <xsl:param name="basePath" select="'/service-root'" />
-  <xsl:param name="basePathInPathTemplate" select="false()" />
+  <xsl:param name="pathTemplateBase" select="$basePath" />
 
   <xsl:param name="info-title" select="null" />
   <xsl:param name="info-description" select="null" />
@@ -1621,8 +1621,8 @@
     <xsl:variable name="entityType" select="//edm:Schema[@Namespace=$namespace]/edm:EntityType[@Name=$type]" />
 
     <xsl:text>"</xsl:text>
-    <xsl:if test="$basePathInPathTemplate">
-      <xsl:value-of select="$basePath" />
+    <xsl:if test="not($pathTemplateBase=$basePath)">
+      <xsl:value-of select="$pathTemplateBase" />
     </xsl:if>
     <xsl:text>/</xsl:text>
     <xsl:if test="$childtype=@Name">
@@ -2075,8 +2075,8 @@
 
     <!-- entity path template -->
     <xsl:text>,"</xsl:text>
-    <xsl:if test="$basePathInPathTemplate">
-      <xsl:value-of select="$basePath" />
+    <xsl:if test="not($pathTemplateBase=$basePath)">
+      <xsl:value-of select="$pathTemplateBase" />
     </xsl:if>
     <xsl:text>/</xsl:text>
     <xsl:if test="$childtype=@Name">


### PR DESCRIPTION
First off, THANK YOU SO MUCH for this project. I spent days trying to find a solution to building a swagger document for my dotnet core OData API (which is currently not supported using the Swashbuckle .NET package).

Short list of changes is below. Note that I haven't tested these changes on a wide variety of APIs, and at least one of the changes (the 'basePath' on the path template) could probably stand to be optionally configured; however, I felt as though these changes may be useful enough for you to at least review and consider for merging into master

- Added support for child entities (i.e. /ParentEntity('parent key')/ChildEntity('child key'))
- Added 'operationId' to operations in paths
- Added 'basePath' to path template
- For swagger-2.0 spec, changed string type to not show as an array with a "nullable" property... Swagger Editor was throwing an error on validating strings like that