### PR TITLE
Containment navigation property insert restrictions

### DIFF
--- a/examples/TripPinNonInsertableNavigation.openapi.json
+++ b/examples/TripPinNonInsertableNavigation.openapi.json
@@ -1,0 +1,2900 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "TripPin service is a sample service for OData V4.",
+    "version": "",
+    "description": "This OData service is located at [https://services.odata.org/V4/(S(cnbm44wtbc1v5bgrlek5lpcc))/TripPinServiceRW/](https://services.odata.org/V4/%28S%28cnbm44wtbc1v5bgrlek5lpcc%29%29/TripPinServiceRW/)\n\n## Entity Data Model\n![ER Diagram](https://yuml.me/diagram/class/[City],[Location],[Location]->[City],[Location]^[EventLocation],[Location]^[AirportLocation],[Photo{bg:orange}],[Person{bg:orange}],[Person]-*>[Location],[Person]-0..1>[PersonGender],[Person]-*>[Person],[Person]++-*>[Trip],[Person]-0..1>[Photo],[Airline{bg:orange}],[Airport{bg:orange}],[Airport]->[AirportLocation],[PlanItem{bg:orange}],[PlanItem]^[PublicTransportation{bg:orange}],[PublicTransportation]^[Flight{bg:orange}],[Flight]->[Airport],[Flight]->[Airport],[Flight]->[Airline],[PlanItem]^[Event{bg:orange}],[Event]->[EventLocation],[Trip{bg:orange}],[Trip]-*>[Photo],[Trip]++-*>[PlanItem])"
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "services.odata.org",
+  "basePath": "/V4/(S(cnbm44wtbc1v5bgrlek5lpcc))/TripPinServiceRW",
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "tags": [
+    {
+      "name": "Photos"
+    },
+    {
+      "name": "People"
+    },
+    {
+      "name": "Airlines"
+    },
+    {
+      "name": "Airports"
+    },
+    {
+      "name": "Me"
+    }
+  ],
+  "paths": {
+    "/Photos": {
+      "get": {
+        "summary": "Get entities from Photos",
+        "tags": [
+          "Photos"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filter items by property values, see [OData Filtering](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionfilter)",
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values, see [OData Sorting](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionorderby)",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "enum": [
+                "Id",
+                "Id desc",
+                "Name",
+                "Name desc"
+              ]
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned, see [OData Select](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionselect)",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "enum": [
+                "Id",
+                "Name"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entities",
+            "schema": {
+              "title": "Collection of Photo",
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Photo"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "post": {
+        "summary": "Add new entity to Photos",
+        "tags": [
+          "Photos"
+        ],
+        "parameters": [
+          {
+            "name": "Photo",
+            "in": "body",
+            "description": "New entity",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Photo-create"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created entity",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Photo"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/Photos({Id})": {
+      "get": {
+        "summary": "Get entity from Photos by key",
+        "tags": [
+          "Photos"
+        ],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "required": true,
+            "description": "key: Id",
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned, see [OData Select](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionselect)",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "enum": [
+                "Id",
+                "Name"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entity",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Photo"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update entity in Photos",
+        "tags": [
+          "Photos"
+        ],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "required": true,
+            "description": "key: Id",
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "Photo",
+            "in": "body",
+            "description": "New property values",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Photo-update"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete entity from Photos",
+        "tags": [
+          "Photos"
+        ],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "required": true,
+            "description": "key: Id",
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/People": {
+      "get": {
+        "summary": "Get entities from People",
+        "tags": [
+          "People"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filter items by property values, see [OData Filtering](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionfilter)",
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values, see [OData Sorting](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionorderby)",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "enum": [
+                "UserName",
+                "UserName desc",
+                "FirstName",
+                "FirstName desc",
+                "LastName",
+                "LastName desc",
+                "Emails",
+                "Emails desc",
+                "AddressInfo",
+                "AddressInfo desc",
+                "Gender",
+                "Gender desc",
+                "Concurrency",
+                "Concurrency desc"
+              ]
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned, see [OData Select](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionselect)",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "Emails",
+                "AddressInfo",
+                "Gender",
+                "Concurrency"
+              ]
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities, see [OData Expand](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionexpand)",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "enum": [
+                "*",
+                "Friends",
+                "Trips",
+                "Photo"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entities",
+            "schema": {
+              "title": "Collection of Person",
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Person"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "post": {
+        "summary": "Add new entity to People",
+        "tags": [
+          "People"
+        ],
+        "parameters": [
+          {
+            "name": "Person",
+            "in": "body",
+            "description": "New entity",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Person-create"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created entity",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Person"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/People('{UserName}')": {
+      "get": {
+        "summary": "Get entity from People by key",
+        "tags": [
+          "People"
+        ],
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "required": true,
+            "description": "key: UserName",
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned, see [OData Select](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionselect)",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "Emails",
+                "AddressInfo",
+                "Gender",
+                "Concurrency"
+              ]
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities, see [OData Expand](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionexpand)",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "enum": [
+                "*",
+                "Friends",
+                "Trips",
+                "Photo"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entity",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Person"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update entity in People",
+        "tags": [
+          "People"
+        ],
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "required": true,
+            "description": "key: UserName",
+            "type": "string"
+          },
+          {
+            "name": "Person",
+            "in": "body",
+            "description": "New property values",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Person-update"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete entity from People",
+        "tags": [
+          "People"
+        ],
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "required": true,
+            "description": "key: UserName",
+            "type": "string"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/People('{UserName}')/Microsoft.OData.SampleService.Models.TripPin.GetFavoriteAirline()": {
+      "get": {
+        "summary": "Invoke function GetFavoriteAirline",
+        "tags": [
+          "People"
+        ],
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "required": true,
+            "description": "key: UserName",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Airline"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/People('{UserName}')/Microsoft.OData.SampleService.Models.TripPin.GetFriendsTrips(userName='{userName}')": {
+      "get": {
+        "summary": "Invoke function GetFriendsTrips",
+        "tags": [
+          "People"
+        ],
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "required": true,
+            "description": "key: UserName",
+            "type": "string"
+          },
+          {
+            "name": "userName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "title": "Collection of Trip",
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Trip"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/People('{UserName}')/Microsoft.OData.SampleService.Models.TripPin.ShareTrip": {
+      "post": {
+        "summary": "Invoke action ShareTrip",
+        "tags": [
+          "People"
+        ],
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "required": true,
+            "description": "key: UserName",
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Action parameters",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": "string"
+                },
+                "tripId": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/People('{UserName}')/Friends": {
+      "get": {
+        "summary": "Get related People",
+        "tags": [
+          "People"
+        ],
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "required": true,
+            "description": "key: UserName",
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filter items by property values, see [OData Filtering](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionfilter)",
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values, see [OData Sorting](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionorderby)",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "enum": [
+                "UserName",
+                "UserName desc",
+                "FirstName",
+                "FirstName desc",
+                "LastName",
+                "LastName desc",
+                "Emails",
+                "Emails desc",
+                "AddressInfo",
+                "AddressInfo desc",
+                "Gender",
+                "Gender desc",
+                "Concurrency",
+                "Concurrency desc"
+              ]
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned, see [OData Select](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionselect)",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "Emails",
+                "AddressInfo",
+                "Gender",
+                "Concurrency"
+              ]
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities, see [OData Expand](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionexpand)",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "enum": [
+                "*",
+                "Friends",
+                "Trips",
+                "Photo"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entities",
+            "schema": {
+              "title": "Collection of Person",
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Person"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "test": "true",
+      "post": {
+        "summary": "Add related Person",
+        "tags": [
+          "People"
+        ],
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "required": true,
+            "description": "key: UserName",
+            "type": "string"
+          },
+          {
+            "name": "Person",
+            "in": "body",
+            "description": "New entity",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Person-create"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created entity",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Person"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/People('{UserName}')/Trips": {
+      "get": {
+        "summary": "Get related Trips",
+        "tags": [
+          "People"
+        ],
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "required": true,
+            "description": "key: UserName",
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filter items by property values, see [OData Filtering](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionfilter)",
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values, see [OData Sorting](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionorderby)",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "enum": [
+                "TripId",
+                "TripId desc",
+                "ShareId",
+                "ShareId desc",
+                "Description",
+                "Description desc",
+                "Name",
+                "Name desc",
+                "Budget",
+                "Budget desc",
+                "StartsAt",
+                "StartsAt desc",
+                "EndsAt",
+                "EndsAt desc",
+                "Tags",
+                "Tags desc"
+              ]
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned, see [OData Select](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionselect)",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "enum": [
+                "TripId",
+                "ShareId",
+                "Description",
+                "Name",
+                "Budget",
+                "StartsAt",
+                "EndsAt",
+                "Tags"
+              ]
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities, see [OData Expand](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionexpand)",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "enum": [
+                "*",
+                "Photos",
+                "PlanItems"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entities",
+            "schema": {
+              "title": "Collection of Trip",
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Trip"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "test": ""
+    },
+    "/People('{UserName}')/Photo": {
+      "get": {
+        "summary": "Get related Photo",
+        "tags": [
+          "People",
+          "Photos"
+        ],
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "required": true,
+            "description": "key: UserName",
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned, see [OData Select](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionselect)",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "enum": [
+                "Id",
+                "Name"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entities",
+            "schema": {
+              "title": "Collection of Photo",
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Photo"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/Airlines": {
+      "get": {
+        "summary": "Get entities from Airlines",
+        "tags": [
+          "Airlines"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filter items by property values, see [OData Filtering](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionfilter)",
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values, see [OData Sorting](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionorderby)",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "enum": [
+                "AirlineCode",
+                "AirlineCode desc",
+                "Name",
+                "Name desc"
+              ]
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned, see [OData Select](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionselect)",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "enum": [
+                "AirlineCode",
+                "Name"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entities",
+            "schema": {
+              "title": "Collection of Airline",
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Airline"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "post": {
+        "summary": "Add new entity to Airlines",
+        "tags": [
+          "Airlines"
+        ],
+        "parameters": [
+          {
+            "name": "Airline",
+            "in": "body",
+            "description": "New entity",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Airline-create"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created entity",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Airline"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/Airlines('{AirlineCode}')": {
+      "get": {
+        "summary": "Get entity from Airlines by key",
+        "tags": [
+          "Airlines"
+        ],
+        "parameters": [
+          {
+            "name": "AirlineCode",
+            "in": "path",
+            "required": true,
+            "description": "key: AirlineCode",
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned, see [OData Select](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionselect)",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "enum": [
+                "AirlineCode",
+                "Name"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entity",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Airline"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update entity in Airlines",
+        "tags": [
+          "Airlines"
+        ],
+        "parameters": [
+          {
+            "name": "AirlineCode",
+            "in": "path",
+            "required": true,
+            "description": "key: AirlineCode",
+            "type": "string"
+          },
+          {
+            "name": "Airline",
+            "in": "body",
+            "description": "New property values",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Airline-update"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete entity from Airlines",
+        "tags": [
+          "Airlines"
+        ],
+        "parameters": [
+          {
+            "name": "AirlineCode",
+            "in": "path",
+            "required": true,
+            "description": "key: AirlineCode",
+            "type": "string"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/Airports": {
+      "get": {
+        "summary": "Get entities from Airports",
+        "tags": [
+          "Airports"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filter items by property values, see [OData Filtering](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionfilter)",
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values, see [OData Sorting](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionorderby)",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "enum": [
+                "IcaoCode",
+                "IcaoCode desc",
+                "Name",
+                "Name desc",
+                "IataCode",
+                "IataCode desc",
+                "Location",
+                "Location desc"
+              ]
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned, see [OData Select](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionselect)",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "enum": [
+                "IcaoCode",
+                "Name",
+                "IataCode",
+                "Location"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entities",
+            "schema": {
+              "title": "Collection of Airport",
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Airport"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/Airports('{IcaoCode}')": {
+      "get": {
+        "summary": "Get entity from Airports by key",
+        "tags": [
+          "Airports"
+        ],
+        "parameters": [
+          {
+            "name": "IcaoCode",
+            "in": "path",
+            "required": true,
+            "description": "key: IcaoCode",
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned, see [OData Select](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionselect)",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "enum": [
+                "IcaoCode",
+                "Name",
+                "IataCode",
+                "Location"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entity",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Airport"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update entity in Airports",
+        "tags": [
+          "Airports"
+        ],
+        "parameters": [
+          {
+            "name": "IcaoCode",
+            "in": "path",
+            "required": true,
+            "description": "key: IcaoCode",
+            "type": "string"
+          },
+          {
+            "name": "Airport",
+            "in": "body",
+            "description": "New property values",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Airport-update"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/Me": {
+      "get": {
+        "summary": "Get Me",
+        "tags": [
+          "Me"
+        ],
+        "parameters": [
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned, see [OData Select](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionselect)",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "Emails",
+                "AddressInfo",
+                "Gender",
+                "Concurrency"
+              ]
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities, see [OData Expand](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionexpand)",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "enum": [
+                "*",
+                "Friends",
+                "Trips",
+                "Photo"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entity",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Person"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update Me",
+        "tags": [
+          "Me"
+        ],
+        "parameters": [
+          {
+            "name": "Person",
+            "in": "body",
+            "description": "New property values",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Person-update"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/Me/Microsoft.OData.SampleService.Models.TripPin.GetFavoriteAirline()": {
+      "get": {
+        "summary": "Invoke function GetFavoriteAirline",
+        "tags": [
+          "Me"
+        ],
+        "parameters": [
+
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Airline"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/Me/Microsoft.OData.SampleService.Models.TripPin.GetFriendsTrips(userName='{userName}')": {
+      "get": {
+        "summary": "Invoke function GetFriendsTrips",
+        "tags": [
+          "Me"
+        ],
+        "parameters": [
+          {
+            "name": "userName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "title": "Collection of Trip",
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Trip"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/Me/Microsoft.OData.SampleService.Models.TripPin.ShareTrip": {
+      "post": {
+        "summary": "Invoke action ShareTrip",
+        "tags": [
+          "Me"
+        ],
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Action parameters",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": "string"
+                },
+                "tripId": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/Me/Friends": {
+      "get": {
+        "summary": "Get related People",
+        "tags": [
+          "Me",
+          "People"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filter items by property values, see [OData Filtering](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionfilter)",
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values, see [OData Sorting](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionorderby)",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "enum": [
+                "UserName",
+                "UserName desc",
+                "FirstName",
+                "FirstName desc",
+                "LastName",
+                "LastName desc",
+                "Emails",
+                "Emails desc",
+                "AddressInfo",
+                "AddressInfo desc",
+                "Gender",
+                "Gender desc",
+                "Concurrency",
+                "Concurrency desc"
+              ]
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned, see [OData Select](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionselect)",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "enum": [
+                "UserName",
+                "FirstName",
+                "LastName",
+                "Emails",
+                "AddressInfo",
+                "Gender",
+                "Concurrency"
+              ]
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities, see [OData Expand](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionexpand)",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "enum": [
+                "*",
+                "Friends",
+                "Trips",
+                "Photo"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entities",
+            "schema": {
+              "title": "Collection of Person",
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Person"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "test": "true",
+      "post": {
+        "summary": "Add related Person",
+        "tags": [
+          "Me",
+          "People"
+        ],
+        "parameters": [
+          {
+            "name": "Person",
+            "in": "body",
+            "description": "New entity",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Person-create"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created entity",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Person"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/Me/Trips": {
+      "get": {
+        "summary": "Get related Trips",
+        "tags": [
+          "Me"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/top"
+          },
+          {
+            "$ref": "#/parameters/skip"
+          },
+          {
+            "$ref": "#/parameters/search"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filter items by property values, see [OData Filtering](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionfilter)",
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values, see [OData Sorting](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionorderby)",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "enum": [
+                "TripId",
+                "TripId desc",
+                "ShareId",
+                "ShareId desc",
+                "Description",
+                "Description desc",
+                "Name",
+                "Name desc",
+                "Budget",
+                "Budget desc",
+                "StartsAt",
+                "StartsAt desc",
+                "EndsAt",
+                "EndsAt desc",
+                "Tags",
+                "Tags desc"
+              ]
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned, see [OData Select](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionselect)",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "enum": [
+                "TripId",
+                "ShareId",
+                "Description",
+                "Name",
+                "Budget",
+                "StartsAt",
+                "EndsAt",
+                "Tags"
+              ]
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities, see [OData Expand](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionexpand)",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "enum": [
+                "*",
+                "Photos",
+                "PlanItems"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entities",
+            "schema": {
+              "title": "Collection of Trip",
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Trip"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      },
+      "test": "",
+      "post": {
+        "summary": "Add related Trip",
+        "tags": [
+          "Me"
+        ],
+        "parameters": [
+          {
+            "name": "Trip",
+            "in": "body",
+            "description": "New entity",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Trip-create"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created entity",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Trip"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/Me/Photo": {
+      "get": {
+        "summary": "Get related Photo",
+        "tags": [
+          "Me",
+          "Photos"
+        ],
+        "parameters": [
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned, see [OData Select](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionselect)",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "enum": [
+                "Id",
+                "Name"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entities",
+            "schema": {
+              "title": "Collection of Photo",
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Photo"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/GetNearestAirport(lat={lat},lon={lon})": {
+      "get": {
+        "summary": "Invoke function GetNearestAirport",
+        "tags": [
+          "Airports"
+        ],
+        "parameters": [
+          {
+            "name": "lat",
+            "in": "path",
+            "required": true,
+            "type": "number",
+            "format": "double"
+          },
+          {
+            "name": "lon",
+            "in": "path",
+            "required": true,
+            "type": "number",
+            "format": "double"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Airport"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    },
+    "/ResetDataSource": {
+      "post": {
+        "summary": "Invoke action ResetDataSource",
+        "tags": [
+          "Service Operations"
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/responses/error"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Microsoft.OData.SampleService.Models.TripPin.PersonGender": {
+      "type": "string",
+      "enum": [
+        "Male",
+        "Female",
+        "Unknown"
+      ],
+      "title": "PersonGender"
+    },
+    "Microsoft.OData.SampleService.Models.TripPin.City": {
+      "type": "object",
+      "properties": {
+        "CountryRegion": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        },
+        "Region": {
+          "type": "string"
+        }
+      },
+      "title": "City"
+    },
+    "Microsoft.OData.SampleService.Models.TripPin.City-create": {
+      "type": "object",
+      "properties": {
+        "CountryRegion": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        },
+        "Region": {
+          "type": "string"
+        }
+      },
+      "title": "City (for create)"
+    },
+    "Microsoft.OData.SampleService.Models.TripPin.City-update": {
+      "type": "object",
+      "properties": {
+        "CountryRegion": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        },
+        "Region": {
+          "type": "string"
+        }
+      },
+      "title": "City (for update)"
+    },
+    "Microsoft.OData.SampleService.Models.TripPin.Location": {
+      "type": "object",
+      "properties": {
+        "Address": {
+          "type": "string"
+        },
+        "City": {
+          "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.City"
+        }
+      },
+      "title": "Location"
+    },
+    "Microsoft.OData.SampleService.Models.TripPin.Location-create": {
+      "type": "object",
+      "properties": {
+        "Address": {
+          "type": "string"
+        },
+        "City": {
+          "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.City-create"
+        }
+      },
+      "title": "Location (for create)"
+    },
+    "Microsoft.OData.SampleService.Models.TripPin.Location-update": {
+      "type": "object",
+      "properties": {
+        "Address": {
+          "type": "string"
+        },
+        "City": {
+          "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.City-update"
+        }
+      },
+      "title": "Location (for update)"
+    },
+    "Microsoft.OData.SampleService.Models.TripPin.EventLocation": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Location"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "BuildingInfo": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "example": "string"
+            }
+          }
+        }
+      ],
+      "title": "EventLocation"
+    },
+    "Microsoft.OData.SampleService.Models.TripPin.EventLocation-create": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Location-create"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "BuildingInfo": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "example": "string"
+            }
+          }
+        }
+      ],
+      "title": "EventLocation (for create)"
+    },
+    "Microsoft.OData.SampleService.Models.TripPin.EventLocation-update": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Location-update"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "BuildingInfo": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "example": "string"
+            }
+          }
+        }
+      ],
+      "title": "EventLocation (for update)"
+    },
+    "Microsoft.OData.SampleService.Models.TripPin.AirportLocation": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Location"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "Loc": {
+              "$ref": "#/definitions/geoPoint"
+            }
+          }
+        }
+      ],
+      "title": "AirportLocation"
+    },
+    "Microsoft.OData.SampleService.Models.TripPin.AirportLocation-create": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Location-create"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "Loc": {
+              "$ref": "#/definitions/geoPoint"
+            }
+          }
+        }
+      ],
+      "title": "AirportLocation (for create)"
+    },
+    "Microsoft.OData.SampleService.Models.TripPin.AirportLocation-update": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Location-update"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "Loc": {
+              "$ref": "#/definitions/geoPoint"
+            }
+          }
+        }
+      ],
+      "title": "AirportLocation (for update)"
+    },
+    "Microsoft.OData.SampleService.Models.TripPin.Photo": {
+      "type": "object",
+      "properties": {
+        "Id": {
+          "type": [
+            "integer",
+            "string"
+          ],
+          "format": "int64",
+          "example": "42"
+        },
+        "Name": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "example": "string"
+        }
+      },
+      "title": "Photo"
+    },
+    "Microsoft.OData.SampleService.Models.TripPin.Photo-create": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "example": "string"
+        }
+      },
+      "title": "Photo (for create)"
+    },
+    "Microsoft.OData.SampleService.Models.TripPin.Photo-update": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "example": "string"
+        }
+      },
+      "title": "Photo (for update)"
+    },
+    "Microsoft.OData.SampleService.Models.TripPin.Person": {
+      "type": "object",
+      "properties": {
+        "UserName": {
+          "type": "string"
+        },
+        "FirstName": {
+          "type": "string"
+        },
+        "LastName": {
+          "type": "string"
+        },
+        "Emails": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "AddressInfo": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Location"
+          }
+        },
+        "Gender": {
+          "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.PersonGender"
+        },
+        "Concurrency": {
+          "type": [
+            "integer",
+            "string"
+          ],
+          "format": "int64",
+          "example": "42"
+        },
+        "Friends": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Person"
+          }
+        },
+        "Trips": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Trip"
+          }
+        },
+        "Photo": {
+          "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Photo"
+        }
+      },
+      "title": "Person"
+    },
+    "Microsoft.OData.SampleService.Models.TripPin.Person-create": {
+      "type": "object",
+      "properties": {
+        "FirstName": {
+          "type": "string"
+        },
+        "LastName": {
+          "type": "string"
+        },
+        "Emails": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "AddressInfo": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Location-create"
+          }
+        },
+        "Gender": {
+          "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.PersonGender"
+        },
+        "Friends": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Person-create"
+          }
+        },
+        "Trips": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Trip-create"
+          }
+        },
+        "Photo": {
+          "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Photo-create"
+        }
+      },
+      "title": "Person (for create)"
+    },
+    "Microsoft.OData.SampleService.Models.TripPin.Person-update": {
+      "type": "object",
+      "properties": {
+        "FirstName": {
+          "type": "string"
+        },
+        "LastName": {
+          "type": "string"
+        },
+        "Emails": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "AddressInfo": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Location-update"
+          }
+        },
+        "Gender": {
+          "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.PersonGender"
+        }
+      },
+      "title": "Person (for update)"
+    },
+    "Microsoft.OData.SampleService.Models.TripPin.Airline": {
+      "type": "object",
+      "properties": {
+        "AirlineCode": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "Airline"
+    },
+    "Microsoft.OData.SampleService.Models.TripPin.Airline-create": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "Airline (for create)"
+    },
+    "Microsoft.OData.SampleService.Models.TripPin.Airline-update": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string"
+        }
+      },
+      "title": "Airline (for update)"
+    },
+    "Microsoft.OData.SampleService.Models.TripPin.Airport": {
+      "type": "object",
+      "properties": {
+        "IcaoCode": {
+          "type": "string"
+        },
+        "Name": {
+          "type": "string"
+        },
+        "IataCode": {
+          "type": "string"
+        },
+        "Location": {
+          "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.AirportLocation"
+        }
+      },
+      "title": "Airport"
+    },
+    "Microsoft.OData.SampleService.Models.TripPin.Airport-create": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string"
+        },
+        "IataCode": {
+          "type": "string"
+        },
+        "Location": {
+          "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.AirportLocation-create"
+        }
+      },
+      "title": "Airport (for create)"
+    },
+    "Microsoft.OData.SampleService.Models.TripPin.Airport-update": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string"
+        },
+        "Location": {
+          "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.AirportLocation-update"
+        }
+      },
+      "title": "Airport (for update)"
+    },
+    "Microsoft.OData.SampleService.Models.TripPin.PlanItem": {
+      "type": "object",
+      "properties": {
+        "PlanItemId": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "ConfirmationCode": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "example": "string"
+        },
+        "StartsAt": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time",
+          "example": "2017-04-13T15:51:04Z"
+        },
+        "EndsAt": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time",
+          "example": "2017-04-13T15:51:04Z"
+        },
+        "Duration": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "duration",
+          "example": "P4DT15H51M04S"
+        }
+      },
+      "title": "PlanItem"
+    },
+    "Microsoft.OData.SampleService.Models.TripPin.PlanItem-create": {
+      "type": "object",
+      "properties": {
+        "ConfirmationCode": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "example": "string"
+        },
+        "StartsAt": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time",
+          "example": "2017-04-13T15:51:04Z"
+        },
+        "EndsAt": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time",
+          "example": "2017-04-13T15:51:04Z"
+        },
+        "Duration": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "duration",
+          "example": "P4DT15H51M04S"
+        }
+      },
+      "title": "PlanItem (for create)"
+    },
+    "Microsoft.OData.SampleService.Models.TripPin.PlanItem-update": {
+      "type": "object",
+      "properties": {
+        "ConfirmationCode": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "example": "string"
+        },
+        "StartsAt": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time",
+          "example": "2017-04-13T15:51:04Z"
+        },
+        "EndsAt": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time",
+          "example": "2017-04-13T15:51:04Z"
+        },
+        "Duration": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "duration",
+          "example": "P4DT15H51M04S"
+        }
+      },
+      "title": "PlanItem (for update)"
+    },
+    "Microsoft.OData.SampleService.Models.TripPin.PublicTransportation": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.PlanItem"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "SeatNumber": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "example": "string"
+            }
+          }
+        }
+      ],
+      "title": "PublicTransportation"
+    },
+    "Microsoft.OData.SampleService.Models.TripPin.PublicTransportation-create": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.PlanItem-create"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "SeatNumber": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "example": "string"
+            }
+          }
+        }
+      ],
+      "title": "PublicTransportation (for create)"
+    },
+    "Microsoft.OData.SampleService.Models.TripPin.PublicTransportation-update": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.PlanItem-update"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "SeatNumber": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "example": "string"
+            }
+          }
+        }
+      ],
+      "title": "PublicTransportation (for update)"
+    },
+    "Microsoft.OData.SampleService.Models.TripPin.Flight": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.PublicTransportation"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "FlightNumber": {
+              "type": "string"
+            },
+            "From": {
+              "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Airport"
+            },
+            "To": {
+              "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Airport"
+            },
+            "Airline": {
+              "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Airline"
+            }
+          }
+        }
+      ],
+      "title": "Flight"
+    },
+    "Microsoft.OData.SampleService.Models.TripPin.Flight-create": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.PublicTransportation-create"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "FlightNumber": {
+              "type": "string"
+            },
+            "From": {
+              "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Airport-create"
+            },
+            "To": {
+              "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Airport-create"
+            },
+            "Airline": {
+              "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Airline-create"
+            }
+          }
+        }
+      ],
+      "title": "Flight (for create)"
+    },
+    "Microsoft.OData.SampleService.Models.TripPin.Flight-update": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.PublicTransportation-update"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "FlightNumber": {
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "title": "Flight (for update)"
+    },
+    "Microsoft.OData.SampleService.Models.TripPin.Event": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.PlanItem"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "Description": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "example": "string"
+            },
+            "OccursAt": {
+              "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.EventLocation"
+            }
+          }
+        }
+      ],
+      "title": "Event"
+    },
+    "Microsoft.OData.SampleService.Models.TripPin.Event-create": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.PlanItem-create"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "Description": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "example": "string"
+            },
+            "OccursAt": {
+              "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.EventLocation-create"
+            }
+          }
+        }
+      ],
+      "title": "Event (for create)"
+    },
+    "Microsoft.OData.SampleService.Models.TripPin.Event-update": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.PlanItem-update"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "Description": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "example": "string"
+            },
+            "OccursAt": {
+              "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.EventLocation-update"
+            }
+          }
+        }
+      ],
+      "title": "Event (for update)"
+    },
+    "Microsoft.OData.SampleService.Models.TripPin.Trip": {
+      "type": "object",
+      "properties": {
+        "TripId": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "ShareId": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uuid",
+          "example": "01234567-89ab-cdef-0123-456789abcdef"
+        },
+        "Description": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "example": "string"
+        },
+        "Name": {
+          "type": "string"
+        },
+        "Budget": {
+          "type": [
+            "number",
+            "string"
+          ],
+          "format": "float",
+          "example": 3.14
+        },
+        "StartsAt": {
+          "type": "string",
+          "format": "date-time",
+          "example": "2017-04-13T15:51:04Z"
+        },
+        "EndsAt": {
+          "type": "string",
+          "format": "date-time",
+          "example": "2017-04-13T15:51:04Z"
+        },
+        "Tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Photos": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Photo"
+          }
+        },
+        "PlanItems": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.PlanItem"
+          }
+        }
+      },
+      "title": "Trip"
+    },
+    "Microsoft.OData.SampleService.Models.TripPin.Trip-create": {
+      "type": "object",
+      "properties": {
+        "ShareId": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uuid",
+          "example": "01234567-89ab-cdef-0123-456789abcdef"
+        },
+        "Description": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "example": "string"
+        },
+        "Name": {
+          "type": "string"
+        },
+        "Budget": {
+          "type": [
+            "number",
+            "string"
+          ],
+          "format": "float",
+          "example": 3.14
+        },
+        "StartsAt": {
+          "type": "string",
+          "format": "date-time",
+          "example": "2017-04-13T15:51:04Z"
+        },
+        "EndsAt": {
+          "type": "string",
+          "format": "date-time",
+          "example": "2017-04-13T15:51:04Z"
+        },
+        "Tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Photos": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.Photo-create"
+          }
+        },
+        "PlanItems": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Microsoft.OData.SampleService.Models.TripPin.PlanItem-create"
+          }
+        }
+      },
+      "title": "Trip (for create)"
+    },
+    "Microsoft.OData.SampleService.Models.TripPin.Trip-update": {
+      "type": "object",
+      "properties": {
+        "ShareId": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uuid",
+          "example": "01234567-89ab-cdef-0123-456789abcdef"
+        },
+        "Description": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "example": "string"
+        },
+        "Name": {
+          "type": "string"
+        },
+        "Budget": {
+          "type": [
+            "number",
+            "string"
+          ],
+          "format": "float",
+          "example": 3.14
+        },
+        "StartsAt": {
+          "type": "string",
+          "format": "date-time",
+          "example": "2017-04-13T15:51:04Z"
+        },
+        "EndsAt": {
+          "type": "string",
+          "format": "date-time",
+          "example": "2017-04-13T15:51:04Z"
+        },
+        "Tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "title": "Trip (for update)"
+    },
+    "geoPoint": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "Point"
+          ],
+          "default": "Point"
+        },
+        "coordinates": {
+          "$ref": "#/definitions/geoPosition"
+        }
+      },
+      "required": [
+        "type",
+        "coordinates"
+      ]
+    },
+    "geoPosition": {
+      "type": "array",
+      "items": {
+        "type": "number"
+      },
+      "minItems": 2
+    },
+    "odata.error": {
+      "type": "object",
+      "required": [
+        "error"
+      ],
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/odata.error.main"
+        }
+      }
+    },
+    "odata.error.main": {
+      "type": "object",
+      "required": [
+        "code",
+        "message"
+      ],
+      "properties": {
+        "code": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "target": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/odata.error.detail"
+          }
+        },
+        "innererror": {
+          "type": "object",
+          "description": "The structure of this object is service-specific"
+        }
+      }
+    },
+    "odata.error.detail": {
+      "type": "object",
+      "required": [
+        "code",
+        "message"
+      ],
+      "properties": {
+        "code": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "target": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "parameters": {
+    "top": {
+      "name": "$top",
+      "in": "query",
+      "description": "Show only the first n items, see [OData Paging - Top](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptiontop)",
+      "type": "integer",
+      "minimum": 0
+    },
+    "skip": {
+      "name": "$skip",
+      "in": "query",
+      "description": "Skip the first n items, see [OData Paging - Skip](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionskip)",
+      "type": "integer",
+      "minimum": 0
+    },
+    "count": {
+      "name": "$count",
+      "in": "query",
+      "description": "Include count of items, see [OData Count](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptioncount)",
+      "type": "boolean"
+    },
+    "search": {
+      "name": "$search",
+      "in": "query",
+      "description": "Search items by search phrases, see [OData Searching](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionsearch)",
+      "type": "string"
+    }
+  },
+  "responses": {
+    "error": {
+      "description": "Error",
+      "schema": {
+        "$ref": "#/definitions/odata.error"
+      }
+    }
+  }
+}

--- a/examples/TripPinNonInsertableNavigation.openapi3.json
+++ b/examples/TripPinNonInsertableNavigation.openapi3.json
@@ -1,0 +1,3205 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "TripPin service is a sample service for OData V4.",
+    "version": "",
+    "description": "This OData service is located at [https://services.odata.org/V4/(S(cnbm44wtbc1v5bgrlek5lpcc))/TripPinServiceRW/](https://services.odata.org/V4/%28S%28cnbm44wtbc1v5bgrlek5lpcc%29%29/TripPinServiceRW/)\n\n## Entity Data Model\n![ER Diagram](https://yuml.me/diagram/class/[City],[Location],[Location]->[City],[Location]^[EventLocation],[Location]^[AirportLocation],[Photo{bg:orange}],[Person{bg:orange}],[Person]-*>[Location],[Person]-0..1>[PersonGender],[Person]-*>[Person],[Person]++-*>[Trip],[Person]-0..1>[Photo],[Airline{bg:orange}],[Airport{bg:orange}],[Airport]->[AirportLocation],[PlanItem{bg:orange}],[PlanItem]^[PublicTransportation{bg:orange}],[PublicTransportation]^[Flight{bg:orange}],[Flight]->[Airport],[Flight]->[Airport],[Flight]->[Airline],[PlanItem]^[Event{bg:orange}],[Event]->[EventLocation],[Trip{bg:orange}],[Trip]-*>[Photo],[Trip]++-*>[PlanItem])"
+  },
+  "servers": [
+    {
+      "url": "https://services.odata.org/V4/(S(cnbm44wtbc1v5bgrlek5lpcc))/TripPinServiceRW"
+    }
+  ],
+  "tags": [
+    {
+      "name": "Photos"
+    },
+    {
+      "name": "People"
+    },
+    {
+      "name": "Airlines"
+    },
+    {
+      "name": "Airports"
+    },
+    {
+      "name": "Me"
+    }
+  ],
+  "paths": {
+    "/Photos": {
+      "get": {
+        "summary": "Get entities from Photos",
+        "tags": [
+          "Photos"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filter items by property values, see [OData Filtering](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionfilter)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values, see [OData Sorting](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionorderby)",
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "Id",
+                  "Id desc",
+                  "Name",
+                  "Name desc"
+                ]
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned, see [OData Select](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionselect)",
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "Id",
+                  "Name"
+                ]
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Collection of Photo",
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Photo"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "post": {
+        "summary": "Add new entity to Photos",
+        "tags": [
+          "Photos"
+        ],
+        "requestBody": {
+          "required": true,
+          "description": "New entity",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Photo-create"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Photo"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/Photos({Id})": {
+      "get": {
+        "summary": "Get entity from Photos by key",
+        "tags": [
+          "Photos"
+        ],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "required": true,
+            "description": "key: Id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "format": "int64",
+              "example": "42"
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned, see [OData Select](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionselect)",
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "Id",
+                  "Name"
+                ]
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Photo"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update entity in Photos",
+        "tags": [
+          "Photos"
+        ],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "required": true,
+            "description": "key: Id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "format": "int64",
+              "example": "42"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Photo-update"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete entity from Photos",
+        "tags": [
+          "Photos"
+        ],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "required": true,
+            "description": "key: Id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "format": "int64",
+              "example": "42"
+            }
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/People": {
+      "get": {
+        "summary": "Get entities from People",
+        "tags": [
+          "People"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filter items by property values, see [OData Filtering](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionfilter)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values, see [OData Sorting](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionorderby)",
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "UserName",
+                  "UserName desc",
+                  "FirstName",
+                  "FirstName desc",
+                  "LastName",
+                  "LastName desc",
+                  "Emails",
+                  "Emails desc",
+                  "AddressInfo",
+                  "AddressInfo desc",
+                  "Gender",
+                  "Gender desc",
+                  "Concurrency",
+                  "Concurrency desc"
+                ]
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned, see [OData Select](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionselect)",
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "UserName",
+                  "FirstName",
+                  "LastName",
+                  "Emails",
+                  "AddressInfo",
+                  "Gender",
+                  "Concurrency"
+                ]
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities, see [OData Expand](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionexpand)",
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "*",
+                  "Friends",
+                  "Trips",
+                  "Photo"
+                ]
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Collection of Person",
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Person"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "post": {
+        "summary": "Add new entity to People",
+        "tags": [
+          "People"
+        ],
+        "requestBody": {
+          "required": true,
+          "description": "New entity",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Person-create"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Person"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/People('{UserName}')": {
+      "get": {
+        "summary": "Get entity from People by key",
+        "tags": [
+          "People"
+        ],
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "required": true,
+            "description": "key: UserName",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned, see [OData Select](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionselect)",
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "UserName",
+                  "FirstName",
+                  "LastName",
+                  "Emails",
+                  "AddressInfo",
+                  "Gender",
+                  "Concurrency"
+                ]
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities, see [OData Expand](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionexpand)",
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "*",
+                  "Friends",
+                  "Trips",
+                  "Photo"
+                ]
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Person"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update entity in People",
+        "tags": [
+          "People"
+        ],
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "required": true,
+            "description": "key: UserName",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Person-update"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete entity from People",
+        "tags": [
+          "People"
+        ],
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "required": true,
+            "description": "key: UserName",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/People('{UserName}')/Microsoft.OData.SampleService.Models.TripPin.GetFavoriteAirline()": {
+      "get": {
+        "summary": "Invoke function GetFavoriteAirline",
+        "tags": [
+          "People"
+        ],
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "required": true,
+            "description": "key: UserName",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Airline"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/People('{UserName}')/Microsoft.OData.SampleService.Models.TripPin.GetFriendsTrips(userName='{userName}')": {
+      "get": {
+        "summary": "Invoke function GetFriendsTrips",
+        "tags": [
+          "People"
+        ],
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "required": true,
+            "description": "key: UserName",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "userName",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Collection of Trip",
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Trip"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/People('{UserName}')/Microsoft.OData.SampleService.Models.TripPin.ShareTrip": {
+      "post": {
+        "summary": "Invoke action ShareTrip",
+        "tags": [
+          "People"
+        ],
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "required": true,
+            "description": "key: UserName",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Action parameters",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "userName": {
+                    "type": "string"
+                  },
+                  "tripId": {
+                    "type": "integer",
+                    "format": "int32"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/People('{UserName}')/Friends": {
+      "get": {
+        "summary": "Get related People",
+        "tags": [
+          "People"
+        ],
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "required": true,
+            "description": "key: UserName",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filter items by property values, see [OData Filtering](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionfilter)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values, see [OData Sorting](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionorderby)",
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "UserName",
+                  "UserName desc",
+                  "FirstName",
+                  "FirstName desc",
+                  "LastName",
+                  "LastName desc",
+                  "Emails",
+                  "Emails desc",
+                  "AddressInfo",
+                  "AddressInfo desc",
+                  "Gender",
+                  "Gender desc",
+                  "Concurrency",
+                  "Concurrency desc"
+                ]
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned, see [OData Select](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionselect)",
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "UserName",
+                  "FirstName",
+                  "LastName",
+                  "Emails",
+                  "AddressInfo",
+                  "Gender",
+                  "Concurrency"
+                ]
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities, see [OData Expand](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionexpand)",
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "*",
+                  "Friends",
+                  "Trips",
+                  "Photo"
+                ]
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Collection of Person",
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Person"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "test": "true",
+      "post": {
+        "summary": "Add related Person",
+        "tags": [
+          "People"
+        ],
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "required": true,
+            "description": "key: UserName",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "description": "New entity",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Person-create"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Person"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/People('{UserName}')/Trips": {
+      "get": {
+        "summary": "Get related Trips",
+        "tags": [
+          "People"
+        ],
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "required": true,
+            "description": "key: UserName",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filter items by property values, see [OData Filtering](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionfilter)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values, see [OData Sorting](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionorderby)",
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "TripId",
+                  "TripId desc",
+                  "ShareId",
+                  "ShareId desc",
+                  "Description",
+                  "Description desc",
+                  "Name",
+                  "Name desc",
+                  "Budget",
+                  "Budget desc",
+                  "StartsAt",
+                  "StartsAt desc",
+                  "EndsAt",
+                  "EndsAt desc",
+                  "Tags",
+                  "Tags desc"
+                ]
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned, see [OData Select](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionselect)",
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "TripId",
+                  "ShareId",
+                  "Description",
+                  "Name",
+                  "Budget",
+                  "StartsAt",
+                  "EndsAt",
+                  "Tags"
+                ]
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities, see [OData Expand](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionexpand)",
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "*",
+                  "Photos",
+                  "PlanItems"
+                ]
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Collection of Trip",
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Trip"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "test": ""
+    },
+    "/People('{UserName}')/Photo": {
+      "get": {
+        "summary": "Get related Photo",
+        "tags": [
+          "People",
+          "Photos"
+        ],
+        "parameters": [
+          {
+            "name": "UserName",
+            "in": "path",
+            "required": true,
+            "description": "key: UserName",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned, see [OData Select](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionselect)",
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "Id",
+                  "Name"
+                ]
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Collection of Photo",
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Photo"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/Airlines": {
+      "get": {
+        "summary": "Get entities from Airlines",
+        "tags": [
+          "Airlines"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filter items by property values, see [OData Filtering](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionfilter)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values, see [OData Sorting](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionorderby)",
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "AirlineCode",
+                  "AirlineCode desc",
+                  "Name",
+                  "Name desc"
+                ]
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned, see [OData Select](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionselect)",
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "AirlineCode",
+                  "Name"
+                ]
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Collection of Airline",
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Airline"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "post": {
+        "summary": "Add new entity to Airlines",
+        "tags": [
+          "Airlines"
+        ],
+        "requestBody": {
+          "required": true,
+          "description": "New entity",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Airline-create"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Airline"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/Airlines('{AirlineCode}')": {
+      "get": {
+        "summary": "Get entity from Airlines by key",
+        "tags": [
+          "Airlines"
+        ],
+        "parameters": [
+          {
+            "name": "AirlineCode",
+            "in": "path",
+            "required": true,
+            "description": "key: AirlineCode",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned, see [OData Select](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionselect)",
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "AirlineCode",
+                  "Name"
+                ]
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Airline"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update entity in Airlines",
+        "tags": [
+          "Airlines"
+        ],
+        "parameters": [
+          {
+            "name": "AirlineCode",
+            "in": "path",
+            "required": true,
+            "description": "key: AirlineCode",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Airline-update"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete entity from Airlines",
+        "tags": [
+          "Airlines"
+        ],
+        "parameters": [
+          {
+            "name": "AirlineCode",
+            "in": "path",
+            "required": true,
+            "description": "key: AirlineCode",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "ETag",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/Airports": {
+      "get": {
+        "summary": "Get entities from Airports",
+        "tags": [
+          "Airports"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filter items by property values, see [OData Filtering](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionfilter)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values, see [OData Sorting](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionorderby)",
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "IcaoCode",
+                  "IcaoCode desc",
+                  "Name",
+                  "Name desc",
+                  "IataCode",
+                  "IataCode desc",
+                  "Location",
+                  "Location desc"
+                ]
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned, see [OData Select](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionselect)",
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "IcaoCode",
+                  "Name",
+                  "IataCode",
+                  "Location"
+                ]
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Collection of Airport",
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Airport"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/Airports('{IcaoCode}')": {
+      "get": {
+        "summary": "Get entity from Airports by key",
+        "tags": [
+          "Airports"
+        ],
+        "parameters": [
+          {
+            "name": "IcaoCode",
+            "in": "path",
+            "required": true,
+            "description": "key: IcaoCode",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned, see [OData Select](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionselect)",
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "IcaoCode",
+                  "Name",
+                  "IataCode",
+                  "Location"
+                ]
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Airport"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update entity in Airports",
+        "tags": [
+          "Airports"
+        ],
+        "parameters": [
+          {
+            "name": "IcaoCode",
+            "in": "path",
+            "required": true,
+            "description": "key: IcaoCode",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Airport-update"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/Me": {
+      "get": {
+        "summary": "Get Me",
+        "tags": [
+          "Me"
+        ],
+        "parameters": [
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned, see [OData Select](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionselect)",
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "UserName",
+                  "FirstName",
+                  "LastName",
+                  "Emails",
+                  "AddressInfo",
+                  "Gender",
+                  "Concurrency"
+                ]
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities, see [OData Expand](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionexpand)",
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "*",
+                  "Friends",
+                  "Trips",
+                  "Photo"
+                ]
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Person"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update Me",
+        "tags": [
+          "Me"
+        ],
+        "requestBody": {
+          "required": true,
+          "description": "New property values",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Person-update"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/Me/Microsoft.OData.SampleService.Models.TripPin.GetFavoriteAirline()": {
+      "get": {
+        "summary": "Invoke function GetFavoriteAirline",
+        "tags": [
+          "Me"
+        ],
+        "parameters": [
+
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Airline"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/Me/Microsoft.OData.SampleService.Models.TripPin.GetFriendsTrips(userName='{userName}')": {
+      "get": {
+        "summary": "Invoke function GetFriendsTrips",
+        "tags": [
+          "Me"
+        ],
+        "parameters": [
+          {
+            "name": "userName",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Collection of Trip",
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Trip"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/Me/Microsoft.OData.SampleService.Models.TripPin.ShareTrip": {
+      "post": {
+        "summary": "Invoke action ShareTrip",
+        "tags": [
+          "Me"
+        ],
+        "requestBody": {
+          "description": "Action parameters",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "userName": {
+                    "type": "string"
+                  },
+                  "tripId": {
+                    "type": "integer",
+                    "format": "int32"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/Me/Friends": {
+      "get": {
+        "summary": "Get related People",
+        "tags": [
+          "Me",
+          "People"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filter items by property values, see [OData Filtering](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionfilter)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values, see [OData Sorting](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionorderby)",
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "UserName",
+                  "UserName desc",
+                  "FirstName",
+                  "FirstName desc",
+                  "LastName",
+                  "LastName desc",
+                  "Emails",
+                  "Emails desc",
+                  "AddressInfo",
+                  "AddressInfo desc",
+                  "Gender",
+                  "Gender desc",
+                  "Concurrency",
+                  "Concurrency desc"
+                ]
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned, see [OData Select](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionselect)",
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "UserName",
+                  "FirstName",
+                  "LastName",
+                  "Emails",
+                  "AddressInfo",
+                  "Gender",
+                  "Concurrency"
+                ]
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities, see [OData Expand](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionexpand)",
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "*",
+                  "Friends",
+                  "Trips",
+                  "Photo"
+                ]
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Collection of Person",
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Person"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "test": "true",
+      "post": {
+        "summary": "Add related Person",
+        "tags": [
+          "Me",
+          "People"
+        ],
+        "parameters": [
+
+        ],
+        "requestBody": {
+          "required": true,
+          "description": "New entity",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Person-create"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Person"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/Me/Trips": {
+      "get": {
+        "summary": "Get related Trips",
+        "tags": [
+          "Me"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/top"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filter items by property values, see [OData Filtering](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionfilter)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/count"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Order items by property values, see [OData Sorting](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionorderby)",
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "TripId",
+                  "TripId desc",
+                  "ShareId",
+                  "ShareId desc",
+                  "Description",
+                  "Description desc",
+                  "Name",
+                  "Name desc",
+                  "Budget",
+                  "Budget desc",
+                  "StartsAt",
+                  "StartsAt desc",
+                  "EndsAt",
+                  "EndsAt desc",
+                  "Tags",
+                  "Tags desc"
+                ]
+              }
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned, see [OData Select](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionselect)",
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "TripId",
+                  "ShareId",
+                  "Description",
+                  "Name",
+                  "Budget",
+                  "StartsAt",
+                  "EndsAt",
+                  "Tags"
+                ]
+              }
+            }
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expand related entities, see [OData Expand](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionexpand)",
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "*",
+                  "Photos",
+                  "PlanItems"
+                ]
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Collection of Trip",
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Trip"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      },
+      "test": "",
+      "post": {
+        "summary": "Add related Trip",
+        "tags": [
+          "Me"
+        ],
+        "parameters": [
+
+        ],
+        "requestBody": {
+          "required": true,
+          "description": "New entity",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Trip-create"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Trip"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/Me/Photo": {
+      "get": {
+        "summary": "Get related Photo",
+        "tags": [
+          "Me",
+          "Photos"
+        ],
+        "parameters": [
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Select properties to be returned, see [OData Select](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionselect)",
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "Id",
+                  "Name"
+                ]
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Retrieved entities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Collection of Photo",
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Photo"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/GetNearestAirport(lat={lat},lon={lon})": {
+      "get": {
+        "summary": "Invoke function GetNearestAirport",
+        "tags": [
+          "Airports"
+        ],
+        "parameters": [
+          {
+            "name": "lat",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "format": "double",
+              "example": 3.14
+            }
+          },
+          {
+            "name": "lon",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "format": "double",
+              "example": 3.14
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Airport"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/ResetDataSource": {
+      "post": {
+        "summary": "Invoke action ResetDataSource",
+        "tags": [
+          "Service Operations"
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "default": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Microsoft.OData.SampleService.Models.TripPin.PersonGender": {
+        "type": "string",
+        "enum": [
+          "Male",
+          "Female",
+          "Unknown"
+        ],
+        "title": "PersonGender"
+      },
+      "Microsoft.OData.SampleService.Models.TripPin.City": {
+        "type": "object",
+        "properties": {
+          "CountryRegion": {
+            "type": "string"
+          },
+          "Name": {
+            "type": "string"
+          },
+          "Region": {
+            "type": "string"
+          }
+        },
+        "title": "City"
+      },
+      "Microsoft.OData.SampleService.Models.TripPin.City-create": {
+        "type": "object",
+        "properties": {
+          "CountryRegion": {
+            "type": "string"
+          },
+          "Name": {
+            "type": "string"
+          },
+          "Region": {
+            "type": "string"
+          }
+        },
+        "title": "City (for create)"
+      },
+      "Microsoft.OData.SampleService.Models.TripPin.City-update": {
+        "type": "object",
+        "properties": {
+          "CountryRegion": {
+            "type": "string"
+          },
+          "Name": {
+            "type": "string"
+          },
+          "Region": {
+            "type": "string"
+          }
+        },
+        "title": "City (for update)"
+      },
+      "Microsoft.OData.SampleService.Models.TripPin.Location": {
+        "type": "object",
+        "properties": {
+          "Address": {
+            "type": "string"
+          },
+          "City": {
+            "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.City"
+          }
+        },
+        "title": "Location"
+      },
+      "Microsoft.OData.SampleService.Models.TripPin.Location-create": {
+        "type": "object",
+        "properties": {
+          "Address": {
+            "type": "string"
+          },
+          "City": {
+            "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.City-create"
+          }
+        },
+        "title": "Location (for create)"
+      },
+      "Microsoft.OData.SampleService.Models.TripPin.Location-update": {
+        "type": "object",
+        "properties": {
+          "Address": {
+            "type": "string"
+          },
+          "City": {
+            "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.City-update"
+          }
+        },
+        "title": "Location (for update)"
+      },
+      "Microsoft.OData.SampleService.Models.TripPin.EventLocation": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Location"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "BuildingInfo": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          }
+        ],
+        "title": "EventLocation"
+      },
+      "Microsoft.OData.SampleService.Models.TripPin.EventLocation-create": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Location-create"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "BuildingInfo": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          }
+        ],
+        "title": "EventLocation (for create)"
+      },
+      "Microsoft.OData.SampleService.Models.TripPin.EventLocation-update": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Location-update"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "BuildingInfo": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          }
+        ],
+        "title": "EventLocation (for update)"
+      },
+      "Microsoft.OData.SampleService.Models.TripPin.AirportLocation": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Location"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "Loc": {
+                "$ref": "#/components/schemas/geoPoint"
+              }
+            }
+          }
+        ],
+        "title": "AirportLocation"
+      },
+      "Microsoft.OData.SampleService.Models.TripPin.AirportLocation-create": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Location-create"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "Loc": {
+                "$ref": "#/components/schemas/geoPoint"
+              }
+            }
+          }
+        ],
+        "title": "AirportLocation (for create)"
+      },
+      "Microsoft.OData.SampleService.Models.TripPin.AirportLocation-update": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Location-update"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "Loc": {
+                "$ref": "#/components/schemas/geoPoint"
+              }
+            }
+          }
+        ],
+        "title": "AirportLocation (for update)"
+      },
+      "Microsoft.OData.SampleService.Models.TripPin.Photo": {
+        "type": "object",
+        "properties": {
+          "Id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "format": "int64",
+            "example": "42"
+          },
+          "Name": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "title": "Photo"
+      },
+      "Microsoft.OData.SampleService.Models.TripPin.Photo-create": {
+        "type": "object",
+        "properties": {
+          "Name": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "title": "Photo (for create)"
+      },
+      "Microsoft.OData.SampleService.Models.TripPin.Photo-update": {
+        "type": "object",
+        "properties": {
+          "Name": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "title": "Photo (for update)"
+      },
+      "Microsoft.OData.SampleService.Models.TripPin.Person": {
+        "type": "object",
+        "properties": {
+          "UserName": {
+            "type": "string"
+          },
+          "FirstName": {
+            "type": "string"
+          },
+          "LastName": {
+            "type": "string"
+          },
+          "Emails": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "AddressInfo": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Location"
+            }
+          },
+          "Gender": {
+            "nullable": true,
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.PersonGender"
+              }
+            ]
+          },
+          "Concurrency": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "format": "int64",
+            "example": "42"
+          },
+          "Friends": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Person"
+            }
+          },
+          "Trips": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Trip"
+            }
+          },
+          "Photo": {
+            "nullable": true,
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Photo"
+              }
+            ]
+          }
+        },
+        "title": "Person"
+      },
+      "Microsoft.OData.SampleService.Models.TripPin.Person-create": {
+        "type": "object",
+        "properties": {
+          "FirstName": {
+            "type": "string"
+          },
+          "LastName": {
+            "type": "string"
+          },
+          "Emails": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "AddressInfo": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Location-create"
+            }
+          },
+          "Gender": {
+            "nullable": true,
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.PersonGender"
+              }
+            ]
+          },
+          "Friends": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Person-create"
+            }
+          },
+          "Trips": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Trip-create"
+            }
+          },
+          "Photo": {
+            "nullable": true,
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Photo-create"
+              }
+            ]
+          }
+        },
+        "title": "Person (for create)"
+      },
+      "Microsoft.OData.SampleService.Models.TripPin.Person-update": {
+        "type": "object",
+        "properties": {
+          "FirstName": {
+            "type": "string"
+          },
+          "LastName": {
+            "type": "string"
+          },
+          "Emails": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "AddressInfo": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Location-update"
+            }
+          },
+          "Gender": {
+            "nullable": true,
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.PersonGender"
+              }
+            ]
+          }
+        },
+        "title": "Person (for update)"
+      },
+      "Microsoft.OData.SampleService.Models.TripPin.Airline": {
+        "type": "object",
+        "properties": {
+          "AirlineCode": {
+            "type": "string"
+          },
+          "Name": {
+            "type": "string"
+          }
+        },
+        "title": "Airline"
+      },
+      "Microsoft.OData.SampleService.Models.TripPin.Airline-create": {
+        "type": "object",
+        "properties": {
+          "Name": {
+            "type": "string"
+          }
+        },
+        "title": "Airline (for create)"
+      },
+      "Microsoft.OData.SampleService.Models.TripPin.Airline-update": {
+        "type": "object",
+        "properties": {
+          "Name": {
+            "type": "string"
+          }
+        },
+        "title": "Airline (for update)"
+      },
+      "Microsoft.OData.SampleService.Models.TripPin.Airport": {
+        "type": "object",
+        "properties": {
+          "IcaoCode": {
+            "type": "string"
+          },
+          "Name": {
+            "type": "string"
+          },
+          "IataCode": {
+            "type": "string"
+          },
+          "Location": {
+            "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.AirportLocation"
+          }
+        },
+        "title": "Airport"
+      },
+      "Microsoft.OData.SampleService.Models.TripPin.Airport-create": {
+        "type": "object",
+        "properties": {
+          "Name": {
+            "type": "string"
+          },
+          "IataCode": {
+            "type": "string"
+          },
+          "Location": {
+            "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.AirportLocation-create"
+          }
+        },
+        "title": "Airport (for create)"
+      },
+      "Microsoft.OData.SampleService.Models.TripPin.Airport-update": {
+        "type": "object",
+        "properties": {
+          "Name": {
+            "type": "string"
+          },
+          "Location": {
+            "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.AirportLocation-update"
+          }
+        },
+        "title": "Airport (for update)"
+      },
+      "Microsoft.OData.SampleService.Models.TripPin.PlanItem": {
+        "type": "object",
+        "properties": {
+          "PlanItemId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "ConfirmationCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "StartsAt": {
+            "type": "string",
+            "nullable": true,
+            "format": "date-time",
+            "example": "2017-04-13T15:51:04Z"
+          },
+          "EndsAt": {
+            "type": "string",
+            "nullable": true,
+            "format": "date-time",
+            "example": "2017-04-13T15:51:04Z"
+          },
+          "Duration": {
+            "type": "string",
+            "nullable": true,
+            "format": "duration",
+            "example": "P4DT15H51M04S"
+          }
+        },
+        "title": "PlanItem"
+      },
+      "Microsoft.OData.SampleService.Models.TripPin.PlanItem-create": {
+        "type": "object",
+        "properties": {
+          "ConfirmationCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "StartsAt": {
+            "type": "string",
+            "nullable": true,
+            "format": "date-time",
+            "example": "2017-04-13T15:51:04Z"
+          },
+          "EndsAt": {
+            "type": "string",
+            "nullable": true,
+            "format": "date-time",
+            "example": "2017-04-13T15:51:04Z"
+          },
+          "Duration": {
+            "type": "string",
+            "nullable": true,
+            "format": "duration",
+            "example": "P4DT15H51M04S"
+          }
+        },
+        "title": "PlanItem (for create)"
+      },
+      "Microsoft.OData.SampleService.Models.TripPin.PlanItem-update": {
+        "type": "object",
+        "properties": {
+          "ConfirmationCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "StartsAt": {
+            "type": "string",
+            "nullable": true,
+            "format": "date-time",
+            "example": "2017-04-13T15:51:04Z"
+          },
+          "EndsAt": {
+            "type": "string",
+            "nullable": true,
+            "format": "date-time",
+            "example": "2017-04-13T15:51:04Z"
+          },
+          "Duration": {
+            "type": "string",
+            "nullable": true,
+            "format": "duration",
+            "example": "P4DT15H51M04S"
+          }
+        },
+        "title": "PlanItem (for update)"
+      },
+      "Microsoft.OData.SampleService.Models.TripPin.PublicTransportation": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.PlanItem"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "SeatNumber": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          }
+        ],
+        "title": "PublicTransportation"
+      },
+      "Microsoft.OData.SampleService.Models.TripPin.PublicTransportation-create": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.PlanItem-create"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "SeatNumber": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          }
+        ],
+        "title": "PublicTransportation (for create)"
+      },
+      "Microsoft.OData.SampleService.Models.TripPin.PublicTransportation-update": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.PlanItem-update"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "SeatNumber": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          }
+        ],
+        "title": "PublicTransportation (for update)"
+      },
+      "Microsoft.OData.SampleService.Models.TripPin.Flight": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.PublicTransportation"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "FlightNumber": {
+                "type": "string"
+              },
+              "From": {
+                "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Airport"
+              },
+              "To": {
+                "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Airport"
+              },
+              "Airline": {
+                "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Airline"
+              }
+            }
+          }
+        ],
+        "title": "Flight"
+      },
+      "Microsoft.OData.SampleService.Models.TripPin.Flight-create": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.PublicTransportation-create"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "FlightNumber": {
+                "type": "string"
+              },
+              "From": {
+                "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Airport-create"
+              },
+              "To": {
+                "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Airport-create"
+              },
+              "Airline": {
+                "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Airline-create"
+              }
+            }
+          }
+        ],
+        "title": "Flight (for create)"
+      },
+      "Microsoft.OData.SampleService.Models.TripPin.Flight-update": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.PublicTransportation-update"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "FlightNumber": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "title": "Flight (for update)"
+      },
+      "Microsoft.OData.SampleService.Models.TripPin.Event": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.PlanItem"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "Description": {
+                "type": "string",
+                "nullable": true
+              },
+              "OccursAt": {
+                "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.EventLocation"
+              }
+            }
+          }
+        ],
+        "title": "Event"
+      },
+      "Microsoft.OData.SampleService.Models.TripPin.Event-create": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.PlanItem-create"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "Description": {
+                "type": "string",
+                "nullable": true
+              },
+              "OccursAt": {
+                "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.EventLocation-create"
+              }
+            }
+          }
+        ],
+        "title": "Event (for create)"
+      },
+      "Microsoft.OData.SampleService.Models.TripPin.Event-update": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.PlanItem-update"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "Description": {
+                "type": "string",
+                "nullable": true
+              },
+              "OccursAt": {
+                "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.EventLocation-update"
+              }
+            }
+          }
+        ],
+        "title": "Event (for update)"
+      },
+      "Microsoft.OData.SampleService.Models.TripPin.Trip": {
+        "type": "object",
+        "properties": {
+          "TripId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "ShareId": {
+            "type": "string",
+            "nullable": true,
+            "format": "uuid",
+            "example": "01234567-89ab-cdef-0123-456789abcdef"
+          },
+          "Description": {
+            "type": "string",
+            "nullable": true
+          },
+          "Name": {
+            "type": "string"
+          },
+          "Budget": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "format": "float",
+            "example": 3.14
+          },
+          "StartsAt": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2017-04-13T15:51:04Z"
+          },
+          "EndsAt": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2017-04-13T15:51:04Z"
+          },
+          "Tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "Photos": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Photo"
+            }
+          },
+          "PlanItems": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.PlanItem"
+            }
+          }
+        },
+        "title": "Trip"
+      },
+      "Microsoft.OData.SampleService.Models.TripPin.Trip-create": {
+        "type": "object",
+        "properties": {
+          "ShareId": {
+            "type": "string",
+            "nullable": true,
+            "format": "uuid",
+            "example": "01234567-89ab-cdef-0123-456789abcdef"
+          },
+          "Description": {
+            "type": "string",
+            "nullable": true
+          },
+          "Name": {
+            "type": "string"
+          },
+          "Budget": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "format": "float",
+            "example": 3.14
+          },
+          "StartsAt": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2017-04-13T15:51:04Z"
+          },
+          "EndsAt": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2017-04-13T15:51:04Z"
+          },
+          "Tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "Photos": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Photo-create"
+            }
+          },
+          "PlanItems": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.PlanItem-create"
+            }
+          }
+        },
+        "title": "Trip (for create)"
+      },
+      "Microsoft.OData.SampleService.Models.TripPin.Trip-update": {
+        "type": "object",
+        "properties": {
+          "ShareId": {
+            "type": "string",
+            "nullable": true,
+            "format": "uuid",
+            "example": "01234567-89ab-cdef-0123-456789abcdef"
+          },
+          "Description": {
+            "type": "string",
+            "nullable": true
+          },
+          "Name": {
+            "type": "string"
+          },
+          "Budget": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "format": "float",
+            "example": 3.14
+          },
+          "StartsAt": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2017-04-13T15:51:04Z"
+          },
+          "EndsAt": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2017-04-13T15:51:04Z"
+          },
+          "Tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "title": "Trip (for update)"
+      },
+      "geoPoint": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "Point"
+            ],
+            "default": "Point"
+          },
+          "coordinates": {
+            "$ref": "#/components/schemas/geoPosition"
+          }
+        },
+        "required": [
+          "type",
+          "coordinates"
+        ]
+      },
+      "geoPosition": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        },
+        "minItems": 2
+      },
+      "odata.error": {
+        "type": "object",
+        "required": [
+          "error"
+        ],
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/odata.error.main"
+          }
+        }
+      },
+      "odata.error.main": {
+        "type": "object",
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string"
+          },
+          "details": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/odata.error.detail"
+            }
+          },
+          "innererror": {
+            "type": "object",
+            "description": "The structure of this object is service-specific"
+          }
+        }
+      },
+      "odata.error.detail": {
+        "type": "object",
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "parameters": {
+      "top": {
+        "name": "$top",
+        "in": "query",
+        "description": "Show only the first n items, see [OData Paging - Top](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptiontop)",
+        "schema": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "example": 50
+      },
+      "skip": {
+        "name": "$skip",
+        "in": "query",
+        "description": "Skip the first n items, see [OData Paging - Skip](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionskip)",
+        "schema": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "count": {
+        "name": "$count",
+        "in": "query",
+        "description": "Include count of items, see [OData Count](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptioncount)",
+        "schema": {
+          "type": "boolean"
+        }
+      },
+      "search": {
+        "name": "$search",
+        "in": "query",
+        "description": "Search items by search phrases, see [OData Searching](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptionsearch)",
+        "schema": {
+          "type": "string"
+        }
+      }
+    },
+    "responses": {
+      "error": {
+        "description": "Error",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/odata.error"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/examples/TripPinNonInsertableNavigation.xml
+++ b/examples/TripPinNonInsertableNavigation.xml
@@ -1,0 +1,367 @@
+<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:Reference Uri="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" />
+  </edmx:Reference>
+  <edmx:Reference Uri="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Measures.V1.xml">
+    <edmx:Include Namespace="Org.OData.Measures.V1" />
+  </edmx:Reference>
+  <edmx:Reference Uri="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" />
+  </edmx:Reference>
+  <edmx:DataServices>
+    <Schema Namespace="Microsoft.OData.SampleService.Models.TripPin" xmlns="http://docs.oasis-open.org/odata/ns/edm" >
+      <EnumType Name="PersonGender">
+        <Member Name="Male" Value="0" />
+        <Member Name="Female" Value="1" />
+        <Member Name="Unknown" Value="2" />
+      </EnumType>
+      <ComplexType Name="City">
+        <Property Name="CountryRegion" Type="Edm.String" Nullable="false" />
+        <Property Name="Name" Type="Edm.String" Nullable="false" />
+        <Property Name="Region" Type="Edm.String" Nullable="false" />
+      </ComplexType>
+      <ComplexType Name="Location" OpenType="true">
+        <Property Name="Address" Type="Edm.String" Nullable="false" />
+        <Property Name="City" Type="Microsoft.OData.SampleService.Models.TripPin.City" Nullable="false" />
+      </ComplexType>
+      <ComplexType Name="EventLocation" BaseType="Microsoft.OData.SampleService.Models.TripPin.Location" OpenType="true">
+        <Property Name="BuildingInfo" Type="Edm.String" />
+      </ComplexType>
+      <ComplexType Name="AirportLocation" BaseType="Microsoft.OData.SampleService.Models.TripPin.Location" OpenType="true">
+        <Property Name="Loc" Type="Edm.GeographyPoint" Nullable="false" SRID="4326" />
+      </ComplexType>
+      <EntityType Name="Photo" HasStream="true">
+        <Key>
+          <PropertyRef Name="Id" />
+        </Key>
+        <Property Name="Id" Type="Edm.Int64" Nullable="false">
+          <Annotation Term="Org.OData.Core.V1.Permissions">
+            <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+          </Annotation>
+        </Property>
+        <Property Name="Name" Type="Edm.String" />
+        <Annotation Term="Org.OData.Core.V1.AcceptableMediaTypes">
+          <Collection>
+            <String>image/jpeg</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+      <EntityType Name="Person" OpenType="true">
+        <Key>
+          <PropertyRef Name="UserName" />
+        </Key>
+        <Property Name="UserName" Type="Edm.String" Nullable="false">
+          <Annotation Term="Org.OData.Core.V1.Permissions">
+            <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+          </Annotation>
+        </Property>
+        <Property Name="FirstName" Type="Edm.String" Nullable="false" />
+        <Property Name="LastName" Type="Edm.String" Nullable="false" />
+        <Property Name="Emails" Type="Collection(Edm.String)" />
+        <Property Name="AddressInfo" Type="Collection(Microsoft.OData.SampleService.Models.TripPin.Location)" />
+        <Property Name="Gender" Type="Microsoft.OData.SampleService.Models.TripPin.PersonGender" />
+        <Property Name="Concurrency" Type="Edm.Int64" Nullable="false">
+          <Annotation Term="Org.OData.Core.V1.Computed" Bool="true" />
+        </Property>
+        <NavigationProperty Name="Friends" Type="Collection(Microsoft.OData.SampleService.Models.TripPin.Person)" />
+        <NavigationProperty Name="Trips" Type="Collection(Microsoft.OData.SampleService.Models.TripPin.Trip)"
+          ContainsTarget="true" />
+        <NavigationProperty Name="Photo" Type="Microsoft.OData.SampleService.Models.TripPin.Photo" />
+      </EntityType>
+      <EntityType Name="Airline">
+        <Key>
+          <PropertyRef Name="AirlineCode" />
+        </Key>
+        <Property Name="AirlineCode" Type="Edm.String" Nullable="false">
+          <Annotation Term="Org.OData.Core.V1.Permissions">
+            <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+          </Annotation>
+        </Property>
+        <Property Name="Name" Type="Edm.String" Nullable="false" />
+      </EntityType>
+      <EntityType Name="Airport">
+        <Key>
+          <PropertyRef Name="IcaoCode" />
+        </Key>
+        <Property Name="IcaoCode" Type="Edm.String" Nullable="false">
+          <Annotation Term="Org.OData.Core.V1.Permissions">
+            <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+          </Annotation>
+        </Property>
+        <Property Name="Name" Type="Edm.String" Nullable="false" />
+        <Property Name="IataCode" Type="Edm.String" Nullable="false">
+          <Annotation Term="Org.OData.Core.V1.Immutable" Bool="true" />
+        </Property>
+        <Property Name="Location" Type="Microsoft.OData.SampleService.Models.TripPin.AirportLocation" Nullable="false" />
+      </EntityType>
+      <EntityType Name="PlanItem">
+        <Key>
+          <PropertyRef Name="PlanItemId" />
+        </Key>
+        <Property Name="PlanItemId" Type="Edm.Int32" Nullable="false">
+          <Annotation Term="Org.OData.Core.V1.Permissions">
+            <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+          </Annotation>
+        </Property>
+        <Property Name="ConfirmationCode" Type="Edm.String" />
+        <Property Name="StartsAt" Type="Edm.DateTimeOffset" />
+        <Property Name="EndsAt" Type="Edm.DateTimeOffset" />
+        <Property Name="Duration" Type="Edm.Duration" />
+      </EntityType>
+      <EntityType Name="PublicTransportation" BaseType="Microsoft.OData.SampleService.Models.TripPin.PlanItem">
+        <Property Name="SeatNumber" Type="Edm.String" />
+      </EntityType>
+      <EntityType Name="Flight" BaseType="Microsoft.OData.SampleService.Models.TripPin.PublicTransportation">
+        <Property Name="FlightNumber" Type="Edm.String" Nullable="false" />
+        <NavigationProperty Name="From" Type="Microsoft.OData.SampleService.Models.TripPin.Airport" Nullable="false" />
+        <NavigationProperty Name="To" Type="Microsoft.OData.SampleService.Models.TripPin.Airport" Nullable="false" />
+        <NavigationProperty Name="Airline" Type="Microsoft.OData.SampleService.Models.TripPin.Airline"
+          Nullable="false" />
+      </EntityType>
+      <EntityType Name="Event" BaseType="Microsoft.OData.SampleService.Models.TripPin.PlanItem" OpenType="true">
+        <Property Name="Description" Type="Edm.String" />
+        <Property Name="OccursAt" Type="Microsoft.OData.SampleService.Models.TripPin.EventLocation" Nullable="false" />
+      </EntityType>
+      <EntityType Name="Trip">
+        <Key>
+          <PropertyRef Name="TripId" />
+        </Key>
+        <Property Name="TripId" Type="Edm.Int32" Nullable="false">
+          <Annotation Term="Org.OData.Core.V1.Permissions">
+            <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+          </Annotation>
+        </Property>
+        <Property Name="ShareId" Type="Edm.Guid" />
+        <Property Name="Description" Type="Edm.String" />
+        <Property Name="Name" Type="Edm.String" Nullable="false" />
+        <Property Name="Budget" Type="Edm.Single" Nullable="false">
+          <Annotation Term="Org.OData.Measures.V1.ISOCurrency" String="USD" />
+          <Annotation Term="Org.OData.Measures.V1.Scale" Int="2" />
+        </Property>
+        <Property Name="StartsAt" Type="Edm.DateTimeOffset" Nullable="false" />
+        <Property Name="EndsAt" Type="Edm.DateTimeOffset" Nullable="false" />
+        <Property Name="Tags" Type="Collection(Edm.String)" Nullable="false" />
+        <NavigationProperty Name="Photos" Type="Collection(Microsoft.OData.SampleService.Models.TripPin.Photo)" />
+        <NavigationProperty Name="PlanItems" Type="Collection(Microsoft.OData.SampleService.Models.TripPin.PlanItem)"
+          ContainsTarget="true" />
+      </EntityType>
+      <Function Name="GetFavoriteAirline" IsBound="true"
+        EntitySetPath="person/Trips/PlanItems/Microsoft.OData.SampleService.Models.TripPin.Flight/Airline" IsComposable="true"
+      >
+        <Parameter Name="person" Type="Microsoft.OData.SampleService.Models.TripPin.Person" Nullable="false" />
+        <ReturnType Type="Microsoft.OData.SampleService.Models.TripPin.Airline" Nullable="false" />
+      </Function>
+      <Function Name="GetInvolvedPeople" IsBound="true" IsComposable="true">
+        <Parameter Name="trip" Type="Microsoft.OData.SampleService.Models.TripPin.Trip" Nullable="false" />
+        <ReturnType Type="Collection(Microsoft.OData.SampleService.Models.TripPin.Person)" Nullable="false" />
+      </Function>
+      <Function Name="GetFriendsTrips" IsBound="true" EntitySetPath="person/Friends/Trips" IsComposable="true">
+        <Parameter Name="person" Type="Microsoft.OData.SampleService.Models.TripPin.Person" Nullable="false" />
+        <Parameter Name="userName" Type="Edm.String" Nullable="false" />
+        <ReturnType Type="Collection(Microsoft.OData.SampleService.Models.TripPin.Trip)" Nullable="false" />
+      </Function>
+      <Function Name="GetNearestAirport" IsComposable="true">
+        <Parameter Name="lat" Type="Edm.Double" Nullable="false" />
+        <Parameter Name="lon" Type="Edm.Double" Nullable="false" />
+        <ReturnType Type="Microsoft.OData.SampleService.Models.TripPin.Airport" Nullable="false" />
+      </Function>
+      <Action Name="ResetDataSource" />
+      <Action Name="ShareTrip" IsBound="true">
+        <Parameter Name="person" Type="Microsoft.OData.SampleService.Models.TripPin.Person" Nullable="false" />
+        <Parameter Name="userName" Type="Edm.String" Nullable="false" />
+        <Parameter Name="tripId" Type="Edm.Int32" Nullable="false" />
+      </Action>
+      <EntityContainer Name="DefaultContainer">
+        <EntitySet Name="Photos" EntityType="Microsoft.OData.SampleService.Models.TripPin.Photo">
+          <Annotation Term="Org.OData.Core.V1.ResourcePath" String="Photos" />
+          <Annotation Term="Org.OData.Capabilities.V1.SearchRestrictions">
+            <Record>
+              <PropertyValue Property="Searchable" Bool="true" />
+              <PropertyValue Property="UnsupportedExpressions">
+                <EnumMember>Org.OData.Capabilities.V1.SearchExpressions/none</EnumMember>
+              </PropertyValue>
+            </Record>
+          </Annotation>
+          <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
+            <Record>
+              <PropertyValue Property="Insertable" Bool="true" />
+              <PropertyValue Property="NonInsertableNavigationProperties">
+                <Collection />
+              </PropertyValue>
+            </Record>
+          </Annotation>
+        </EntitySet>
+        <EntitySet Name="People" EntityType="Microsoft.OData.SampleService.Models.TripPin.Person">
+          <NavigationPropertyBinding Path="Friends" Target="People" />
+          <NavigationPropertyBinding Path="Microsoft.OData.SampleService.Models.TripPin.Flight/Airline"
+            Target="Airlines" />
+          <NavigationPropertyBinding Path="Microsoft.OData.SampleService.Models.TripPin.Flight/From"
+            Target="Airports" />
+          <NavigationPropertyBinding Path="Microsoft.OData.SampleService.Models.TripPin.Flight/To"
+            Target="Airports" />
+          <NavigationPropertyBinding Path="Photo" Target="Photos" />
+          <NavigationPropertyBinding Path="Microsoft.OData.SampleService.Models.TripPin.Trip/Photos"
+            Target="Photos" />
+          <Annotation Term="Org.OData.Core.V1.OptimisticConcurrency">
+            <Collection>
+              <PropertyPath>Concurrency</PropertyPath>
+            </Collection>
+          </Annotation>
+          <Annotation Term="Org.OData.Core.V1.ResourcePath" String="People" />
+          <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
+            <Record>
+              <PropertyValue Property="Navigability">
+                <EnumMember>Org.OData.Capabilities.V1.NavigationType/None</EnumMember>
+              </PropertyValue>
+              <PropertyValue Property="RestrictedProperties">
+                <Collection>
+                  <Record>
+                    <PropertyValue Property="NavigationProperty" NavigationPropertyPath="Friends" />
+                    <PropertyValue Property="Navigability">
+                      <EnumMember>Org.OData.Capabilities.V1.NavigationType/Recursive</EnumMember>
+                    </PropertyValue>
+                  </Record>
+				  <Record>
+					<PropertyValue Property="NavigationProperty" PropertyPath="Trips"/>
+					<PropertyValue Property="InsertRestrictions">
+						<Record>
+							<PropertyValue Property="Insertable" Bool="false" />
+						</Record>
+					</PropertyValue>
+                  </Record>
+                </Collection>
+              </PropertyValue>
+            </Record>
+          </Annotation>
+          <Annotation Term="Org.OData.Capabilities.V1.SearchRestrictions">
+            <Record>
+              <PropertyValue Property="Searchable" Bool="true" />
+              <PropertyValue Property="UnsupportedExpressions">
+                <EnumMember>Org.OData.Capabilities.V1.SearchExpressions/none</EnumMember>
+              </PropertyValue>
+            </Record>
+          </Annotation>
+          <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
+            <Record>
+              <PropertyValue Property="Insertable" Bool="true" />
+              <PropertyValue Property="NonInsertableNavigationProperties">
+                <Collection>
+                  <NavigationPropertyPath>Trips</NavigationPropertyPath>
+                  <NavigationPropertyPath>Friends</NavigationPropertyPath>
+                </Collection>
+              </PropertyValue>
+            </Record>
+          </Annotation>
+        </EntitySet>
+        <EntitySet Name="Airlines" EntityType="Microsoft.OData.SampleService.Models.TripPin.Airline">
+          <Annotation Term="Org.OData.Core.V1.ResourcePath" String="Airlines" />
+          <Annotation Term="Org.OData.Capabilities.V1.SearchRestrictions">
+            <Record>
+              <PropertyValue Property="Searchable" Bool="true" />
+              <PropertyValue Property="UnsupportedExpressions">
+                <EnumMember>Org.OData.Capabilities.V1.SearchExpressions/none</EnumMember>
+              </PropertyValue>
+            </Record>
+          </Annotation>
+          <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
+            <Record>
+              <PropertyValue Property="Insertable" Bool="true" />
+              <PropertyValue Property="NonInsertableNavigationProperties">
+                <Collection />
+              </PropertyValue>
+            </Record>
+          </Annotation>
+        </EntitySet>
+        <EntitySet Name="Airports" EntityType="Microsoft.OData.SampleService.Models.TripPin.Airport">
+          <Annotation Term="Org.OData.Core.V1.ResourcePath" String="Airports" />
+          <Annotation Term="Org.OData.Capabilities.V1.SearchRestrictions">
+            <Record>
+              <PropertyValue Property="Searchable" Bool="true" />
+              <PropertyValue Property="UnsupportedExpressions">
+                <EnumMember>Org.OData.Capabilities.V1.SearchExpressions/none</EnumMember>
+              </PropertyValue>
+            </Record>
+          </Annotation>
+          <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
+            <Record>
+              <PropertyValue Property="Insertable" Bool="false" />
+              <PropertyValue Property="NonInsertableNavigationProperties">
+                <Collection />
+              </PropertyValue>
+            </Record>
+          </Annotation>
+          <Annotation Term="Org.OData.Capabilities.V1.DeleteRestrictions">
+            <Record>
+              <PropertyValue Property="Deletable" Bool="false" />
+              <PropertyValue Property="NonDeletableNavigationProperties">
+                <Collection />
+              </PropertyValue>
+            </Record>
+          </Annotation>
+        </EntitySet>
+        <Singleton Name="Me" Type="Microsoft.OData.SampleService.Models.TripPin.Person">
+          <NavigationPropertyBinding Path="Friends" Target="People" />
+          <NavigationPropertyBinding Path="Microsoft.OData.SampleService.Models.TripPin.Flight/Airline"
+            Target="Airlines" />
+          <NavigationPropertyBinding Path="Microsoft.OData.SampleService.Models.TripPin.Flight/From"
+            Target="Airports" />
+          <NavigationPropertyBinding Path="Microsoft.OData.SampleService.Models.TripPin.Flight/To"
+            Target="Airports" />
+          <NavigationPropertyBinding Path="Photo" Target="Photos" />
+          <NavigationPropertyBinding Path="Microsoft.OData.SampleService.Models.TripPin.Trip/Photos"
+            Target="Photos" />
+          <Annotation Term="Org.OData.Core.V1.ResourcePath" String="Me" />
+        </Singleton>
+        <FunctionImport Name="GetNearestAirport" Function="Microsoft.OData.SampleService.Models.TripPin.GetNearestAirport"
+          EntitySet="Airports" IncludeInServiceDocument="true"
+        >
+          <Annotation Term="Org.OData.Core.V1.ResourcePath" String="Microsoft.OData.SampleService.Models.TripPin.GetNearestAirport" />
+        </FunctionImport>
+        <ActionImport Name="ResetDataSource" Action="Microsoft.OData.SampleService.Models.TripPin.ResetDataSource" />
+        <Annotation Term="Org.OData.Core.V1.Description" String="TripPin service is a sample service for OData V4." />
+      </EntityContainer>
+      <Annotations Target="Microsoft.OData.SampleService.Models.TripPin.DefaultContainer">
+        <Annotation Term="Org.OData.Core.V1.DereferenceableIDs" Bool="true" />
+        <Annotation Term="Org.OData.Core.V1.ConventionalIDs" Bool="true" />
+        <Annotation Term="Org.OData.Capabilities.V1.ConformanceLevel">
+          <EnumMember>Org.OData.Capabilities.V1.ConformanceLevelType/Advanced</EnumMember>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.SupportedFormats">
+          <Collection>
+            <String>application/json;odata.metadata=full;IEEE754Compatible=false;odata.streaming=true</String>
+            <String>application/json;odata.metadata=minimal;IEEE754Compatible=false;odata.streaming=true</String>
+            <String>application/json;odata.metadata=none;IEEE754Compatible=false;odata.streaming=true</String>
+          </Collection>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.AsynchronousRequestsSupported" Bool="true" />
+        <Annotation Term="Org.OData.Capabilities.V1.BatchContinueOnErrorSupported" Bool="false" />
+        <Annotation Term="Org.OData.Capabilities.V1.FilterFunctions">
+          <Collection>
+            <String>contains</String>
+            <String>endswith</String>
+            <String>startswith</String>
+            <String>length</String>
+            <String>indexof</String>
+            <String>substring</String>
+            <String>tolower</String>
+            <String>toupper</String>
+            <String>trim</String>
+            <String>concat</String>
+            <String>year</String>
+            <String>month</String>
+            <String>day</String>
+            <String>hour</String>
+            <String>minute</String>
+            <String>second</String>
+            <String>round</String>
+            <String>floor</String>
+            <String>ceiling</String>
+            <String>cast</String>
+            <String>isof</String>
+          </Collection>
+        </Annotation>
+      </Annotations>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/tools/V4-CSDL-to-OpenAPI.xsl
+++ b/tools/V4-CSDL-to-OpenAPI.xsl
@@ -3255,20 +3255,27 @@
 
       <!-- GET -->
       <xsl:text>"get":{</xsl:text>
-
-      <xsl:text>"summary":"Get related </xsl:text>
-      <xsl:choose>
-        <xsl:when test="not($collection)">
-          <xsl:value-of select="$simpleName" />
-        </xsl:when>
-        <xsl:when test="$targetSet">
-          <xsl:value-of select="$targetSet/@Name" />
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:value-of select="@Name" />
-        </xsl:otherwise>
-      </xsl:choose>
-      <xsl:text>","tags":["</xsl:text>
+	  <!-- Dynamic Description of Navigation endpoints -->
+	  <xsl:call-template name="summary-description-qualified">
+        <xsl:with-param name="node" select="$source/edm:NavigationPropertyBinding[@Path=$name]" />
+        <xsl:with-param name="qualifier" select="'Query'" />
+        <xsl:with-param name="fallback-summary">
+          <xsl:text>Get related </xsl:text>
+		  <xsl:choose>
+			<xsl:when test="not($collection)">
+			  <xsl:value-of select="$simpleName" />
+			</xsl:when>
+			<xsl:when test="$targetSet">
+			  <xsl:value-of select="$targetSet/@Name" />
+			</xsl:when>
+			<xsl:otherwise>
+			  <xsl:value-of select="@Name" />
+			</xsl:otherwise>
+		  </xsl:choose>
+		</xsl:with-param>
+      </xsl:call-template>
+	  
+      <xsl:text>,"tags":["</xsl:text>
       <xsl:value-of select="$source/@Name" />
       <xsl:if test="not($resultContext) and $targetSet and $targetSet/@Name!=$source/@Name">
         <xsl:text>","</xsl:text>

--- a/tools/V4-CSDL-to-OpenAPI.xsl
+++ b/tools/V4-CSDL-to-OpenAPI.xsl
@@ -3327,7 +3327,7 @@
         <xsl:variable name="navigation-insertable"
           select="$insertRestrictions/edm:Record/edm:PropertyValue[@Property='Insertable']/@Bool" />
 
-        <xsl:if test="not($insertable='false') or $navigation-insertable='true'">
+        <xsl:if test="($insertable='' and not($navigation-insertable)) or $insertable='true' or $navigation-insertable='true'">
           <xsl:text>,"post":{</xsl:text>
 
           <xsl:text>"summary":"Add related </xsl:text>

--- a/tools/V4-CSDL-to-OpenAPI.xsl
+++ b/tools/V4-CSDL-to-OpenAPI.xsl
@@ -3257,7 +3257,7 @@
       <xsl:text>"get":{</xsl:text>
 	  <!-- Dynamic Description of Navigation endpoints -->
 	  <xsl:call-template name="summary-description-qualified">
-        <xsl:with-param name="node" select="$source/edm:NavigationPropertyBinding[@Path=$name]" />
+        <xsl:with-param name="node" select="." />
         <xsl:with-param name="qualifier" select="'Query'" />
         <xsl:with-param name="fallback-summary">
           <xsl:text>Get related </xsl:text>

--- a/tools/transform.txt
+++ b/tools/transform.txt
@@ -20,6 +20,9 @@ example.xml   https services.odata.org /V4/OData/(S(nsga2k1tyctb0cn0ofcgcn4o))/O
 Northwind.xml https services.odata.org /V4/Northwind/Northwind.svc
 TripPin.xml   https services.odata.org /V4/(S(cnbm44wtbc1v5bgrlek5lpcc))/TripPinServiceRW
 
+# Containment Navigation Property InsertRestrictions
+TripPinNonInsertableNavigation.xml   https services.odata.org /V4/(S(cnbm44wtbc1v5bgrlek5lpcc))/TripPinServiceRW
+
 # live V2 service at www.odata.org
 odata-rw-v2.xml  https services.odata.org /V2/(S(j4g3x2g225evharuxieq0ay3))/OData/OData.svc V2
 Northwind-V2.xml https services.odata.org /V2/Northwind/Northwind.svc                       V2


### PR DESCRIPTION
We have updated the OpenAPI XSL to restrict adding POST endpoint for containment navigation property. For example, TripPin.xml defined with property "Trips" as containment navigation. It adds POST endpoint "/People('{UserName}')/Trips" to OpenAPI specification. It is not removing POST endpoint even after adding navigation insert restrictions as follows,
```xml
<PropertyValue Property="RestrictedProperties">
    <Collection>
      <Record>
        <PropertyValue Property="NavigationProperty" PropertyPath="Trips"/>
        <PropertyValue Property="InsertRestrictions">
            <Record>
                <PropertyValue Property="Insertable" Bool="false" />
            </Record>
        </PropertyValue>
      </Record>
    </Collection>
</PropertyValue>
```
The OpenAPI xsl has been updated such that POST endpoint will not be added for containment navigation properties. The sample odata **TripPinNonInsertableNavigation.xml** is also included in the examples.