### PR TITLE
Updated package.json dep so it would use https by default to pull

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "main": "lib/csdl2openapi.js",
   "dependencies": {
     "minimist": "^1.2.0",
-    "odata-csdl": "oasis-tcs/odata-csdl-schemas"
+    "odata-csdl": "git+https://github.com/oasis-tcs/odata-csdl-schemas"
   },
   "devDependencies": {
     "mocha": "^6.1.4"


### PR DESCRIPTION
I had issues pulling the deps because it was reverting to git (SSH) to pull the assets from behind a corporate firewall. Setting this avoids any problems.