### PR TITLE
Update to use non-negative integer for the count property

### DIFF
--- a/examples/ExampleService.openapi3.json
+++ b/examples/ExampleService.openapi3.json
@@ -9012,7 +9012,8 @@
             "count": {
                 "anyOf": [
                     {
-                        "type": "number"
+                        "type": "integer",
+                        "minimum": 0
                     },
                     {
                         "type": "string"

--- a/examples/Northwind-V3.openapi3.json
+++ b/examples/Northwind-V3.openapi3.json
@@ -13749,7 +13749,8 @@
             "count": {
                 "anyOf": [
                     {
-                        "type": "number"
+                        "type": "integer",
+                        "minimum": 0
                     },
                     {
                         "type": "string"

--- a/examples/Northwind-key-as-segment.openapi3.json
+++ b/examples/Northwind-key-as-segment.openapi3.json
@@ -13866,7 +13866,8 @@
             "count": {
                 "anyOf": [
                     {
-                        "type": "number"
+                        "type": "integer",
+                        "minimum": 0
                     },
                     {
                         "type": "string"

--- a/examples/Northwind.openapi3.json
+++ b/examples/Northwind.openapi3.json
@@ -13866,7 +13866,8 @@
             "count": {
                 "anyOf": [
                     {
-                        "type": "number"
+                        "type": "integer",
+                        "minimum": 0
                     },
                     {
                         "type": "string"

--- a/examples/People.openapi3.json
+++ b/examples/People.openapi3.json
@@ -1739,7 +1739,8 @@
             "count": {
                 "anyOf": [
                     {
-                        "type": "number"
+                        "type": "integer",
+                        "minimum": 0
                     },
                     {
                         "type": "string"

--- a/examples/Products.openapi3.json
+++ b/examples/Products.openapi3.json
@@ -2405,7 +2405,8 @@
             "count": {
                 "anyOf": [
                     {
-                        "type": "number"
+                        "type": "integer",
+                        "minimum": 0
                     },
                     {
                         "type": "string"

--- a/examples/TripPin.openapi3.json
+++ b/examples/TripPin.openapi3.json
@@ -4400,7 +4400,8 @@
             "count": {
                 "anyOf": [
                     {
-                        "type": "number"
+                        "type": "integer",
+                        "minimum": 0
                     },
                     {
                         "type": "string"

--- a/examples/aggregation.openapi3.json
+++ b/examples/aggregation.openapi3.json
@@ -1267,7 +1267,8 @@
             "count": {
                 "anyOf": [
                     {
-                        "type": "number"
+                        "type": "integer",
+                        "minimum": 0
                     },
                     {
                         "type": "string"

--- a/examples/annotations.openapi3.json
+++ b/examples/annotations.openapi3.json
@@ -3013,7 +3013,8 @@
             "count": {
                 "anyOf": [
                     {
-                        "type": "number"
+                        "type": "integer",
+                        "minimum": 0
                     },
                     {
                         "type": "string"

--- a/examples/authorization.openapi3.json
+++ b/examples/authorization.openapi3.json
@@ -315,7 +315,8 @@
             "count": {
                 "anyOf": [
                     {
-                        "type": "number"
+                        "type": "integer",
+                        "minimum": 0
                     },
                     {
                         "type": "string"

--- a/examples/containment.openapi3.json
+++ b/examples/containment.openapi3.json
@@ -5144,7 +5144,8 @@
             "count": {
                 "anyOf": [
                     {
-                        "type": "number"
+                        "type": "integer",
+                        "minimum": 0
                     },
                     {
                         "type": "string"

--- a/examples/csdl-16.1.openapi3.json
+++ b/examples/csdl-16.1.openapi3.json
@@ -2394,7 +2394,8 @@
             "count": {
                 "anyOf": [
                     {
-                        "type": "number"
+                        "type": "integer",
+                        "minimum": 0
                     },
                     {
                         "type": "string"

--- a/examples/descriptions.openapi3.json
+++ b/examples/descriptions.openapi3.json
@@ -1312,7 +1312,8 @@
             "count": {
                 "anyOf": [
                     {
-                        "type": "number"
+                        "type": "integer",
+                        "minimum": 0
                     },
                     {
                         "type": "string"

--- a/examples/example.openapi3.json
+++ b/examples/example.openapi3.json
@@ -4272,7 +4272,8 @@
             "count": {
                 "anyOf": [
                     {
-                        "type": "number"
+                        "type": "integer",
+                        "minimum": 0
                     },
                     {
                         "type": "string"

--- a/examples/key-aliases.openapi3.json
+++ b/examples/key-aliases.openapi3.json
@@ -332,7 +332,8 @@
             "count": {
                 "anyOf": [
                     {
-                        "type": "number"
+                        "type": "integer",
+                        "minimum": 0
                     },
                     {
                         "type": "string"

--- a/examples/odata-rw-v3.openapi3.json
+++ b/examples/odata-rw-v3.openapi3.json
@@ -4280,7 +4280,8 @@
             "count": {
                 "anyOf": [
                     {
-                        "type": "number"
+                        "type": "integer",
+                        "minimum": 0
                     },
                     {
                         "type": "string"

--- a/lib/csdl2openapi.js
+++ b/lib/csdl2openapi.js
@@ -2412,7 +2412,13 @@ module.exports.csdl2openapi = function (
    */
   function count() {
     return {
-      anyOf: [{ type: "number" }, { type: "string" }],
+      anyOf: [
+        {
+          type: "integer",
+          minimum: 0
+        },
+        { type: "string" }
+      ],
       description:
         "The number of entities in the collection. Available when using the [$count](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_SystemQueryOptioncount) query option.",
     };


### PR DESCRIPTION
As an OpenAPI 'number' the count is being advertised as potentially a number such as -54.23746, which causes confusing output in auto-generated schema examples.

This change types the property as a non-negative integer instead.
