### PR TITLE
Fix: annotations on bound action overloads

### DIFF
--- a/lib/csdl2openapi.js
+++ b/lib/csdl2openapi.js
@@ -181,7 +181,10 @@ module.exports.csdl2openapi = function (
                   overload.$IsBound != true &&
                   args == "") ||
                 (overload.$Kind == "Action" &&
-                  args == (overload.$Parameter[0].$Type || "")) ||
+                  args ==
+                    (overload.$Parameter?.[0].$Collection
+                      ? `Collection(${overload.$Parameter[0].$Type})`
+                      : overload.$Parameter[0].$Type || "")) ||
                 (overload.$Parameter || [])
                   .map((p) => {
                     const type = p.$Type || "Edm.String";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "odata-openapi",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "odata-openapi",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "minimist": "^1.2.6",
-        "odata-csdl": "^0.4.0"
+        "odata-csdl": "^0.4.4"
       },
       "bin": {
         "odata-openapi3": "lib/cli.js"
@@ -1541,12 +1541,12 @@
       }
     },
     "node_modules/odata-csdl": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/odata-csdl/-/odata-csdl-0.4.3.tgz",
-      "integrity": "sha512-d7GWZ9lAP4YVyFc+LVZgcEzdi1E6lgusGwX7oSTCRKiMv1xf4Y2CKhb5A2DOCVhyYclrhsoGD/Q5bOSwTLip+g==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/odata-csdl/-/odata-csdl-0.4.4.tgz",
+      "integrity": "sha512-TEQnuqXoQmXBhqEJuIbyajWz1d4wwMVdvw+fiM3QO1G9DjWC+pByJEv4ADQ1aBPA8c2BWHzo8Qw5SZQ6GfKC0A==",
       "dependencies": {
         "colors": "^1.4.0",
-        "minimist": "^1.2.5",
+        "minimist": "^1.2.6",
         "sax": "^1.2.4"
       },
       "bin": {
@@ -3274,12 +3274,12 @@
       "dev": true
     },
     "odata-csdl": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/odata-csdl/-/odata-csdl-0.4.3.tgz",
-      "integrity": "sha512-d7GWZ9lAP4YVyFc+LVZgcEzdi1E6lgusGwX7oSTCRKiMv1xf4Y2CKhb5A2DOCVhyYclrhsoGD/Q5bOSwTLip+g==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/odata-csdl/-/odata-csdl-0.4.4.tgz",
+      "integrity": "sha512-TEQnuqXoQmXBhqEJuIbyajWz1d4wwMVdvw+fiM3QO1G9DjWC+pByJEv4ADQ1aBPA8c2BWHzo8Qw5SZQ6GfKC0A==",
       "requires": {
         "colors": "^1.4.0",
-        "minimist": "^1.2.5",
+        "minimist": "^1.2.6",
         "sax": "^1.2.4"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "odata-openapi",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Convert OData CSDL XML or CSDL JSON to OpenAPI",
   "homepage": "https://github.com/oasis-tcs/odata-openapi/blob/master/lib/README.md",
   "bugs": "https://github.com/oasis-tcs/odata-openapi/issues",
@@ -17,7 +17,7 @@
   "main": "lib/csdl2openapi.js",
   "dependencies": {
     "minimist": "^1.2.6",
-    "odata-csdl": "^0.4.0"
+    "odata-csdl": "^0.4.4"
   },
   "devDependencies": {
     "@apidevtools/openapi-schemas": "^2.1.0",

--- a/test/csdl2openapi.test.js
+++ b/test/csdl2openapi.test.js
@@ -2516,6 +2516,7 @@ describe("Edge cases", function () {
             $IsBound: true,
             $Parameter: [
               { $Name: "in", $Type: "this.root", $Collection: true },
+              { $Name: "other" },
             ],
           },
         ],
@@ -2548,6 +2549,9 @@ describe("Edge cases", function () {
             "@Core.Description":
               "Annotations targeting all overloads are currently ignored",
           },
+          "this.act(Collection(this.root))": {
+            "@Core.Description": "Act!",
+          },
         },
       },
     };
@@ -2559,8 +2563,19 @@ describe("Edge cases", function () {
         "/roots": { get: {}, post: {} },
         "/roots/act": {
           post: {
-            summary: "Invoke action act",
+            summary: "Act!",
             tags: ["roots"],
+            requestBody: {
+              description: "Action parameters",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: { other: { type: "string" } },
+                  },
+                },
+              },
+            },
             responses: {
               204: {
                 description: "Success",


### PR DESCRIPTION
- External annotations on action overloads bound to collection with non-binding parameters now are correctly assigned
- Updated dependencies and package version