### PR TITLE
Support OData V2 sap:label and sap:quickinfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.28.0 - 2024-08-06
+
+### Added
+
+- Support [SAP OData V2 annotations](https://github.com/SAP/odata-vocabularies/blob/main/docs/v2-annotations.md#element-edmproperty) `label` and `quickinfo` on properties, and `label` on entity types and parameters
+
 ## 0.27.1 - 2024-08-01
 
 ### Fixed

--- a/examples/PingTest_V1.no-batch.openapi3.json
+++ b/examples/PingTest_V1.no-batch.openapi3.json
@@ -90,7 +90,7 @@
         "/PingTestSet('{DummyKey}')": {
             "parameters": [
                 {
-                    "description": "key: DummyKey",
+                    "description": "Einstelliges Kennzeichen",
                     "in": "path",
                     "name": "DummyKey",
                     "required": true,
@@ -156,7 +156,8 @@
                 "properties": {
                     "DummyKey": {
                         "type": "string",
-                        "maxLength": 1
+                        "maxLength": 1,
+                        "title": "Einstelliges Kennzeichen"
                     },
                     "Client": {
                         "type": "string",

--- a/examples/PingTest_V1.openapi3.json
+++ b/examples/PingTest_V1.openapi3.json
@@ -90,7 +90,7 @@
         "/PingTestSet('{DummyKey}')": {
             "parameters": [
                 {
-                    "description": "key: DummyKey",
+                    "description": "Einstelliges Kennzeichen",
                     "in": "path",
                     "name": "DummyKey",
                     "required": true,
@@ -193,7 +193,8 @@
                 "properties": {
                     "DummyKey": {
                         "type": "string",
-                        "maxLength": 1
+                        "maxLength": 1,
+                        "title": "Einstelliges Kennzeichen"
                     },
                     "Client": {
                         "type": "string",

--- a/examples/TitleAndDescription.openapi3.json
+++ b/examples/TitleAndDescription.openapi3.json
@@ -90,7 +90,7 @@
         "/PingTestSet('{DummyKey}')": {
             "parameters": [
                 {
-                    "description": "key: DummyKey",
+                    "description": "Einstelliges Kennzeichen",
                     "in": "path",
                     "name": "DummyKey",
                     "required": true,
@@ -193,7 +193,8 @@
                 "properties": {
                     "DummyKey": {
                         "type": "string",
-                        "maxLength": 1
+                        "maxLength": 1,
+                        "title": "Einstelliges Kennzeichen"
                     },
                     "Client": {
                         "type": "string",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "odata-openapi",
-  "version": "0.27.1",
+  "version": "0.28.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "odata-openapi",
-      "version": "0.27.1",
+      "version": "0.28.0",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.0",
-        "odata-csdl": "^0.11.0"
+        "odata-csdl": "^0.11.1"
       },
       "bin": {
         "odata-openapi3": "lib/cli.js"
@@ -1785,9 +1785,9 @@
       }
     },
     "node_modules/odata-csdl": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/odata-csdl/-/odata-csdl-0.11.0.tgz",
-      "integrity": "sha512-KG+DVhXyRNzeqqu13pA6l0nQwCupolPEP6EWBjeFWcrt6JYC80bAH5DewdKOTYvQC2Qy/jFfhh8hCkYrvXsqkg==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/odata-csdl/-/odata-csdl-0.11.1.tgz",
+      "integrity": "sha512-1Ikpy6U2QeJ8O4QhgT0h483zsduvqms2QVHNqLMYVrD+wu6QmdHTyT6nppGVWpCRhgWRqnic9ZIQh29bRjuIEw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "colors": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.0",
-        "odata-csdl": "^0.10.1"
+        "odata-csdl": "^0.11.0"
       },
       "bin": {
         "odata-openapi3": "lib/cli.js"
@@ -1785,9 +1785,9 @@
       }
     },
     "node_modules/odata-csdl": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/odata-csdl/-/odata-csdl-0.10.1.tgz",
-      "integrity": "sha512-gLYaUFDEO+HlZ8q4ApMjh/aRRDVKLlhT9tv6AO+Umcuy23PUAYTM9WxKVsJpi9a7AO04JBxSMjVrjroAUIY2AA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/odata-csdl/-/odata-csdl-0.11.0.tgz",
+      "integrity": "sha512-KG+DVhXyRNzeqqu13pA6l0nQwCupolPEP6EWBjeFWcrt6JYC80bAH5DewdKOTYvQC2Qy/jFfhh8hCkYrvXsqkg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "colors": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "exports": "./lib/csdl2openapi.js",
   "dependencies": {
     "@discoveryjs/json-ext": "^0.6.0",
-    "odata-csdl": "^0.11.0"
+    "odata-csdl": "^0.11.1"
   },
   "devDependencies": {
     "@apidevtools/openapi-schemas": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "odata-openapi",
-  "version": "0.27.1",
+  "version": "0.28.0",
   "description": "Convert OData CSDL XML or CSDL JSON to OpenAPI",
   "homepage": "https://github.com/oasis-tcs/odata-openapi/blob/master/lib/README.md",
   "bugs": "https://github.com/oasis-tcs/odata-openapi/issues",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "exports": "./lib/csdl2openapi.js",
   "dependencies": {
     "@discoveryjs/json-ext": "^0.6.0",
-    "odata-csdl": "^0.10.1"
+    "odata-csdl": "^0.11.0"
   },
   "devDependencies": {
     "@apidevtools/openapi-schemas": "^2.1.0",


### PR DESCRIPTION
Fixes #308 for the JavaScript-based converter (already worked in the XSLT-based variant)