### PR TITLE
Nullable function parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.28.1 - 2024-08-29
+
+### Fixed
+
+- Nullable function parameters no longer get a funny format and a wrong type
+
 ## 0.28.0 - 2024-08-06
 
 ### Added

--- a/examples/csdl-16.1.openapi3.json
+++ b/examples/csdl-16.1.openapi3.json
@@ -1884,8 +1884,8 @@
                         "in": "query",
                         "name": "Rating",
                         "schema": {
-                            "type": "string",
-                            "format": "int32,null",
+                            "type": "integer",
+                            "format": "int32",
                             "nullable": true,
                             "default": "null"
                         }

--- a/lib/csdl2openapi.js
+++ b/lib/csdl2openapi.js
@@ -2728,8 +2728,6 @@ module.exports.csdl2openapi = function (
         s.pattern = "^'([^']|'')*'$";
       }
       if (element.$Nullable) {
-        if (!s.anyOf && !s.allOf) s.type = "string";
-        if (s.format) s.format += ",null";
         s.default = "null"; //TODO: @Core.OptionalParameter.DefaultValue
         if (s.pattern) {
           s.pattern = s.pattern.replace(/^\^/, "^(null|");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "odata-openapi",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "odata-openapi",
-      "version": "0.28.0",
+      "version": "0.28.1",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "odata-openapi",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "description": "Convert OData CSDL XML or CSDL JSON to OpenAPI",
   "homepage": "https://github.com/oasis-tcs/odata-openapi/blob/master/lib/README.md",
   "bugs": "https://github.com/oasis-tcs/odata-openapi/issues",

--- a/test/csdl2openapi.test.js
+++ b/test/csdl2openapi.test.js
@@ -648,7 +648,7 @@ describe("Edge cases", function () {
           required: true,
           schema: {
             type: "string",
-            format: "uuid,null",
+            format: "uuid",
             nullable: true,
             default: "null",
             example: "01234567-89ab-cdef-0123-456789abcdef",
@@ -674,8 +674,8 @@ describe("Edge cases", function () {
           name: "int32Null",
           required: true,
           schema: {
-            type: "string",
-            format: "int32,null",
+            type: "integer",
+            format: "int32",
             nullable: true,
             default: "null",
           },
@@ -702,7 +702,7 @@ describe("Edge cases", function () {
           required: true,
           schema: {
             type: "string",
-            format: "base64url,null",
+            format: "base64url",
             nullable: true,
             default: "null",
           },
@@ -727,7 +727,7 @@ describe("Edge cases", function () {
           name: "booleanNull",
           required: true,
           schema: {
-            type: "string",
+            type: "boolean",
             nullable: true,
             default: "null",
           },
@@ -755,7 +755,7 @@ describe("Edge cases", function () {
           required: true,
           schema: {
             anyOf: [{ type: "number" }, { type: "string" }],
-            format: "decimal,null",
+            format: "decimal",
             nullable: true,
             default: "null",
             example: 0,
@@ -784,7 +784,7 @@ describe("Edge cases", function () {
           required: true,
           schema: {
             type: "string",
-            format: "duration,null",
+            format: "duration",
             nullable: true,
             default: "null",
             example: "'P4DT15H51M04S'",


### PR DESCRIPTION
Function parameters in OData V4 have the same representation as key literals:
* preserve `type` and `format`
* only add `"nullable": true` and adjust pattern for strings