### PR TITLE
XSLT, OData V2: no direct create for non-addressable entity sets

### DIFF
--- a/tools/V2-to-V4-CSDL.xsl
+++ b/tools/V2-to-V4-CSDL.xsl
@@ -1210,12 +1210,6 @@
     </xsl:attribute>
   </xsl:template>
 
-  <xsl:template match="@sap:containstarget">
-    <xsl:attribute name="ContainsTarget">
-      <xsl:value-of select="." />
-    </xsl:attribute>
-  </xsl:template>
-
   <xsl:template match="@sap:*">
     <xsl:message>
       <xsl:value-of select="name(..)" />

--- a/tools/V2-to-V4-CSDL.xsl
+++ b/tools/V2-to-V4-CSDL.xsl
@@ -466,6 +466,15 @@
               </PropertyValue>
             </Record>
           </PropertyValue>
+          <xsl:if test="not($targetSet/@sap:creatable='false')">
+            <PropertyValue Property="InsertRestrictions">
+              <Record>
+                <PropertyValue Property="Insertable">
+                  <Bool>true</Bool>
+                </PropertyValue>
+              </Record>
+            </PropertyValue>
+          </xsl:if>
         </Record>
       </xsl:if>
     </xsl:if>
@@ -1030,6 +1039,15 @@
               </Record>
             </PropertyValue>
           </xsl:if>
+        </Record>
+      </Annotation>
+      <Annotation>
+        <xsl:attribute name="Term">
+          <xsl:value-of select="$Capabilities" />
+          <xsl:text>.InsertRestrictions</xsl:text>
+        </xsl:attribute>
+        <Record>
+          <PropertyValue Property="Insertable" Bool="false" />
         </Record>
       </Annotation>
     </xsl:if>

--- a/tools/V2-to-V4-CSDL.xsl
+++ b/tools/V2-to-V4-CSDL.xsl
@@ -1050,24 +1050,6 @@
           <PropertyValue Property="Insertable" Bool="false" />
         </Record>
       </Annotation>
-      <Annotation>
-        <xsl:attribute name="Term">
-          <xsl:value-of select="$Capabilities" />
-          <xsl:text>.UpdateRestrictions</xsl:text>
-        </xsl:attribute>
-        <Record>
-          <PropertyValue Property="Updatable" Bool="false" />
-        </Record>
-      </Annotation>
-      <Annotation>
-        <xsl:attribute name="Term">
-          <xsl:value-of select="$Capabilities" />
-          <xsl:text>.DeleteRestrictions</xsl:text>
-        </xsl:attribute>
-        <Record>
-          <PropertyValue Property="Deletable" Bool="false" />
-        </Record>
-      </Annotation>
     </xsl:if>
   </xsl:template>
 

--- a/tools/V2-to-V4-CSDL.xsl
+++ b/tools/V2-to-V4-CSDL.xsl
@@ -1050,6 +1050,24 @@
           <PropertyValue Property="Insertable" Bool="false" />
         </Record>
       </Annotation>
+      <Annotation>
+        <xsl:attribute name="Term">
+          <xsl:value-of select="$Capabilities" />
+          <xsl:text>.UpdateRestrictions</xsl:text>
+        </xsl:attribute>
+        <Record>
+          <PropertyValue Property="Updatable" Bool="false" />
+        </Record>
+      </Annotation>
+      <Annotation>
+        <xsl:attribute name="Term">
+          <xsl:value-of select="$Capabilities" />
+          <xsl:text>.DeleteRestrictions</xsl:text>
+        </xsl:attribute>
+        <Record>
+          <PropertyValue Property="Deletable" Bool="false" />
+        </Record>
+      </Annotation>
     </xsl:if>
   </xsl:template>
 

--- a/tools/tests/addressable-v2.openapi3.json
+++ b/tools/tests/addressable-v2.openapi3.json
@@ -1,0 +1,731 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "Service for namespace ZE_API_DEMO_SRV",
+        "version": "",
+        "description": "This service is located at [https://localhost/service-root/](https://localhost/service-root/)\n\n## Entity Data Model\n![ER Diagram](https://yuml.me/diagram/class/[Head{bg:orange}],[Head]-*>[Address{bg:orange}],[Address{bg:orange}],[HeadSet{bg:dodgerblue}]++-*>[Head],[AddressSet{bg:dodgerblue}]++-*>[Address])\n\n### Legend\n![Legend](https://yuml.me/diagram/plain;dir:TB;scale:60/class/[External.Type{bg:whitesmoke}],[ComplexType],[EntityType{bg:orange}],[EntitySet/Singleton/Operation{bg:dodgerblue}])"
+    },
+    "servers": [
+        {
+            "url": "https://localhost/service-root"
+        }
+    ],
+    "tags": [
+        {
+            "name": "HeadSet"
+        },
+        {
+            "name": "AddressSet"
+        }
+    ],
+    "paths": {
+        "/HeadSet": {
+            "get": {
+                "summary": "Get entities from HeadSet",
+                "tags": [
+                    "HeadSet"
+                ],
+                "parameters": [
+                    {
+                        "name": "$filter",
+                        "in": "query",
+                        "description": "Filter items by property values, see [Filtering](https://help.sap.com/doc/5890d27be418427993fafa6722cdc03b/Cloud/en-US/OdataV2.pdf#page=64)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/count"
+                    },
+                    {
+                        "name": "$select",
+                        "in": "query",
+                        "description": "Select properties to be returned, see [Select](https://help.sap.com/doc/5890d27be418427993fafa6722cdc03b/Cloud/en-US/OdataV2.pdf#page=68)",
+                        "explode": false,
+                        "schema": {
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "BusinessPartner",
+                                    "Type",
+                                    "Grouping",
+                                    "Title",
+                                    "FirstName",
+                                    "LastName",
+                                    "IsBlocked",
+                                    "ETag",
+                                    "to_Address"
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        "name": "$expand",
+                        "in": "query",
+                        "description": "Expand related entities, see [Expand](https://help.sap.com/doc/5890d27be418427993fafa6722cdc03b/Cloud/en-US/OdataV2.pdf#page=63)",
+                        "explode": false,
+                        "schema": {
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "to_Address"
+                                ]
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Retrieved entities",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "title": "Wrapper",
+                                    "type": "object",
+                                    "properties": {
+                                        "d": {
+                                            "title": "Collection of Head",
+                                            "type": "object",
+                                            "properties": {
+                                                "__count": {
+                                                    "$ref": "#/components/schemas/count"
+                                                },
+                                                "results": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/ZE_API_DEMO_SRV.Head"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "4XX": {
+                        "$ref": "#/components/responses/error"
+                    }
+                }
+            },
+            "post": {
+                "summary": "Add new entity to HeadSet",
+                "tags": [
+                    "HeadSet"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "description": "New entity",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ZE_API_DEMO_SRV.Head-create"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Created entity",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "title": "Head",
+                                    "type": "object",
+                                    "properties": {
+                                        "d": {
+                                            "$ref": "#/components/schemas/ZE_API_DEMO_SRV.Head"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "4XX": {
+                        "$ref": "#/components/responses/error"
+                    }
+                }
+            }
+        },
+        "/HeadSet('{BusinessPartner}')": {
+            "parameters": [
+                {
+                    "name": "BusinessPartner",
+                    "in": "path",
+                    "required": true,
+                    "description": "Geschäftspartnernummer",
+                    "schema": {
+                        "type": "string",
+                        "maxLength": 10
+                    }
+                }
+            ],
+            "get": {
+                "summary": "Get entity from HeadSet by key",
+                "tags": [
+                    "HeadSet"
+                ],
+                "parameters": [
+                    {
+                        "name": "$select",
+                        "in": "query",
+                        "description": "Select properties to be returned, see [Select](https://help.sap.com/doc/5890d27be418427993fafa6722cdc03b/Cloud/en-US/OdataV2.pdf#page=68)",
+                        "explode": false,
+                        "schema": {
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "BusinessPartner",
+                                    "Type",
+                                    "Grouping",
+                                    "Title",
+                                    "FirstName",
+                                    "LastName",
+                                    "IsBlocked",
+                                    "ETag",
+                                    "to_Address"
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        "name": "$expand",
+                        "in": "query",
+                        "description": "Expand related entities, see [Expand](https://help.sap.com/doc/5890d27be418427993fafa6722cdc03b/Cloud/en-US/OdataV2.pdf#page=63)",
+                        "explode": false,
+                        "schema": {
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "to_Address"
+                                ]
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Retrieved entity",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "title": "Head",
+                                    "type": "object",
+                                    "properties": {
+                                        "d": {
+                                            "$ref": "#/components/schemas/ZE_API_DEMO_SRV.Head"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "4XX": {
+                        "$ref": "#/components/responses/error"
+                    }
+                }
+            }
+        },
+        "/HeadSet('{BusinessPartner}')/to_Address": {
+            "parameters": [
+                {
+                    "name": "BusinessPartner",
+                    "in": "path",
+                    "required": true,
+                    "description": "Geschäftspartnernummer",
+                    "schema": {
+                        "type": "string",
+                        "maxLength": 10
+                    }
+                }
+            ],
+            "get": {
+                "summary": "Get entities from related to_Address",
+                "tags": [
+                    "HeadSet",
+                    "AddressSet"
+                ],
+                "parameters": [
+                    {
+                        "name": "$filter",
+                        "in": "query",
+                        "description": "Filter items by property values, see [Filtering](https://help.sap.com/doc/5890d27be418427993fafa6722cdc03b/Cloud/en-US/OdataV2.pdf#page=64)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/count"
+                    },
+                    {
+                        "name": "$select",
+                        "in": "query",
+                        "description": "Select properties to be returned, see [Select](https://help.sap.com/doc/5890d27be418427993fafa6722cdc03b/Cloud/en-US/OdataV2.pdf#page=68)",
+                        "explode": false,
+                        "schema": {
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "BusinessPartner",
+                                    "AddressId",
+                                    "District",
+                                    "Street",
+                                    "HouseNumber",
+                                    "PostalCode",
+                                    "City",
+                                    "Country",
+                                    "ETag"
+                                ]
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Retrieved entities",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "title": "Wrapper",
+                                    "type": "object",
+                                    "properties": {
+                                        "d": {
+                                            "title": "Collection of Address",
+                                            "type": "object",
+                                            "properties": {
+                                                "__count": {
+                                                    "$ref": "#/components/schemas/count"
+                                                },
+                                                "results": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/ZE_API_DEMO_SRV.Address"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "4XX": {
+                        "$ref": "#/components/responses/error"
+                    }
+                }
+            },
+            "post": {
+                "summary": "Add new entity to related to_Address",
+                "tags": [
+                    "HeadSet",
+                    "AddressSet"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "description": "New entity",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ZE_API_DEMO_SRV.Address-create"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Created entity",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "title": "Address",
+                                    "type": "object",
+                                    "properties": {
+                                        "d": {
+                                            "$ref": "#/components/schemas/ZE_API_DEMO_SRV.Address"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "4XX": {
+                        "$ref": "#/components/responses/error"
+                    }
+                }
+            }
+        },
+        "/AddressSet": {
+            "post": {
+                "summary": "Add new entity to AddressSet",
+                "tags": [
+                    "AddressSet"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "description": "New entity",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ZE_API_DEMO_SRV.Address-create"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Created entity",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "title": "Address",
+                                    "type": "object",
+                                    "properties": {
+                                        "d": {
+                                            "$ref": "#/components/schemas/ZE_API_DEMO_SRV.Address"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "4XX": {
+                        "$ref": "#/components/responses/error"
+                    }
+                }
+            }
+        },
+        "/$batch": {
+            "post": {
+                "summary": "Send a group of requests",
+                "description": "Group multiple requests into a single request payload, see [Batch Requests](https://help.sap.com/doc/5890d27be418427993fafa6722cdc03b/Cloud/en-US/OdataV2.pdf#page=152).\n\n*Please note that \"Try it out\" is not supported for this request.*",
+                "tags": [
+                    "Batch Requests"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "description": "Batch request",
+                    "content": {
+                        "multipart/mixed;boundary=request-separator": {
+                            "schema": {
+                                "type": "string"
+                            },
+                            "example": "--request-separator\nContent-Type: application/http\nContent-Transfer-Encoding: binary\n\nGET HeadSet HTTP/1.1\nAccept: application/json\n\n\n--request-separator--"
+                        }
+                    }
+                },
+                "responses": {
+                    "202": {
+                        "description": "Batch response",
+                        "content": {
+                            "multipart/mixed": {
+                                "schema": {
+                                    "type": "string"
+                                },
+                                "example": "--response-separator\nContent-Type: application/http\n\nHTTP/1.1 200 OK\nContent-Type: application/json\n\n{...}\n--response-separator--"
+                            }
+                        }
+                    },
+                    "4XX": {
+                        "$ref": "#/components/responses/error"
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "ZE_API_DEMO_SRV.Head": {
+                "type": "object",
+                "properties": {
+                    "BusinessPartner": {
+                        "type": "string",
+                        "maxLength": 10,
+                        "title": "GeschPartner",
+                        "description": "Geschäftspartnernummer"
+                    },
+                    "Type": {
+                        "type": "string",
+                        "maxLength": 4,
+                        "title": "Partnerart",
+                        "description": "Geschäftspartnerart"
+                    },
+                    "Grouping": {
+                        "type": "string",
+                        "maxLength": 4,
+                        "title": "Gruppierung",
+                        "description": "Geschäftspartnergruppierung"
+                    },
+                    "Title": {
+                        "type": "string",
+                        "maxLength": 4,
+                        "title": "Anrede",
+                        "description": "Anredeschlüssel"
+                    },
+                    "FirstName": {
+                        "type": "string",
+                        "maxLength": 40,
+                        "title": "Vorname",
+                        "description": "Vorname des Geschäftspartners (Person)"
+                    },
+                    "LastName": {
+                        "type": "string",
+                        "maxLength": 40,
+                        "title": "Nachname",
+                        "description": "Nachname des Geschäftspartners (Person)"
+                    },
+                    "IsBlocked": {
+                        "type": "boolean",
+                        "title": "Zentrale Sperre",
+                        "description": "Zentrale Sperre für den Geschäftspartner"
+                    },
+                    "ETag": {
+                        "type": "string",
+                        "maxLength": 40,
+                        "title": "Hash-Wert",
+                        "description": "Hash-Wert (160 Bits)"
+                    },
+                    "to_Address": {
+                        "type": "object",
+                        "properties": {
+                            "results": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/ZE_API_DEMO_SRV.Address"
+                                }
+                            }
+                        }
+                    }
+                },
+                "title": "Head"
+            },
+            "ZE_API_DEMO_SRV.Head-create": {
+                "type": "object",
+                "properties": {
+                    "Title": {
+                        "type": "string",
+                        "maxLength": 4,
+                        "title": "Anrede",
+                        "description": "Anredeschlüssel"
+                    },
+                    "FirstName": {
+                        "type": "string",
+                        "maxLength": 40,
+                        "title": "Vorname",
+                        "description": "Vorname des Geschäftspartners (Person)"
+                    },
+                    "LastName": {
+                        "type": "string",
+                        "maxLength": 40,
+                        "title": "Nachname",
+                        "description": "Nachname des Geschäftspartners (Person)"
+                    },
+                    "to_Address": {
+                        "type": "object",
+                        "properties": {
+                            "results": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/ZE_API_DEMO_SRV.Address-create"
+                                }
+                            }
+                        }
+                    }
+                },
+                "title": "Head (for create)"
+            },
+            "ZE_API_DEMO_SRV.Head-update": {
+                "type": "object",
+                "title": "Head (for update)"
+            },
+            "ZE_API_DEMO_SRV.Address": {
+                "type": "object",
+                "properties": {
+                    "BusinessPartner": {
+                        "type": "string",
+                        "maxLength": 10,
+                        "title": "GeschPartner",
+                        "description": "Geschäftspartnernummer"
+                    },
+                    "AddressId": {
+                        "type": "string",
+                        "maxLength": 10,
+                        "title": "Adressnummer"
+                    },
+                    "District": {
+                        "type": "string",
+                        "maxLength": 40,
+                        "title": "Ortsteil"
+                    },
+                    "Street": {
+                        "type": "string",
+                        "maxLength": 60,
+                        "title": "Straße"
+                    },
+                    "HouseNumber": {
+                        "type": "string",
+                        "maxLength": 10,
+                        "title": "Hausnummer"
+                    },
+                    "PostalCode": {
+                        "type": "string",
+                        "maxLength": 10,
+                        "title": "Postleitzahl",
+                        "description": "Postleitzahl des Orts"
+                    },
+                    "City": {
+                        "type": "string",
+                        "maxLength": 40,
+                        "title": "Ort"
+                    },
+                    "Country": {
+                        "type": "string",
+                        "maxLength": 2,
+                        "title": "ISO-Code",
+                        "description": "ISO-Code des Landes"
+                    },
+                    "ETag": {
+                        "type": "string",
+                        "maxLength": 40,
+                        "title": "Hash-Wert",
+                        "description": "Hash-Wert (160 Bits)"
+                    }
+                },
+                "title": "Address"
+            },
+            "ZE_API_DEMO_SRV.Address-create": {
+                "type": "object",
+                "properties": {
+                    "District": {
+                        "type": "string",
+                        "maxLength": 40,
+                        "title": "Ortsteil"
+                    },
+                    "Street": {
+                        "type": "string",
+                        "maxLength": 60,
+                        "title": "Straße"
+                    },
+                    "HouseNumber": {
+                        "type": "string",
+                        "maxLength": 10,
+                        "title": "Hausnummer"
+                    },
+                    "PostalCode": {
+                        "type": "string",
+                        "maxLength": 10,
+                        "title": "Postleitzahl",
+                        "description": "Postleitzahl des Orts"
+                    },
+                    "City": {
+                        "type": "string",
+                        "maxLength": 40,
+                        "title": "Ort"
+                    }
+                },
+                "title": "Address (for create)"
+            },
+            "ZE_API_DEMO_SRV.Address-update": {
+                "type": "object",
+                "title": "Address (for update)"
+            },
+            "count": {
+                "type": "string",
+                "description": "The number of entities in the collection. Available when using the [$inlinecount](https://help.sap.com/doc/5890d27be418427993fafa6722cdc03b/Cloud/en-US/OdataV2.pdf#page=67) query option."
+            },
+            "error": {
+                "type": "object",
+                "required": [
+                    "error"
+                ],
+                "properties": {
+                    "error": {
+                        "type": "object",
+                        "required": [
+                            "code",
+                            "message"
+                        ],
+                        "properties": {
+                            "code": {
+                                "type": "string"
+                            },
+                            "message": {
+                                "type": "object",
+                                "required": [
+                                    "lang",
+                                    "value"
+                                ],
+                                "properties": {
+                                    "lang": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "innererror": {
+                                "type": "object",
+                                "description": "The structure of this object is service-specific"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "parameters": {
+            "top": {
+                "name": "$top",
+                "in": "query",
+                "description": "Show only the first n items, see [Paging - Top](https://help.sap.com/doc/5890d27be418427993fafa6722cdc03b/Cloud/en-US/OdataV2.pdf#page=66)",
+                "schema": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "example": 50
+            },
+            "skip": {
+                "name": "$skip",
+                "in": "query",
+                "description": "Skip the first n items, see [Paging - Skip](https://help.sap.com/doc/5890d27be418427993fafa6722cdc03b/Cloud/en-US/OdataV2.pdf#page=65)",
+                "schema": {
+                    "type": "integer",
+                    "minimum": 0
+                }
+            },
+            "count": {
+                "name": "$inlinecount",
+                "in": "query",
+                "description": "Include count of items, see [Inlinecount](https://help.sap.com/doc/5890d27be418427993fafa6722cdc03b/Cloud/en-US/OdataV2.pdf#page=67)",
+                "schema": {
+                    "type": "string",
+                    "enum": [
+                        "allpages",
+                        "none"
+                    ]
+                }
+            }
+        },
+        "responses": {
+            "error": {
+                "description": "Error",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/error"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tools/tests/addressable-v2.openapi3.json
+++ b/tools/tests/addressable-v2.openapi3.json
@@ -364,46 +364,6 @@
                 }
             }
         },
-        "/AddressSet": {
-            "post": {
-                "summary": "Add new entity to AddressSet",
-                "tags": [
-                    "AddressSet"
-                ],
-                "requestBody": {
-                    "required": true,
-                    "description": "New entity",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ZE_API_DEMO_SRV.Address-create"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "201": {
-                        "description": "Created entity",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "title": "Address",
-                                    "type": "object",
-                                    "properties": {
-                                        "d": {
-                                            "$ref": "#/components/schemas/ZE_API_DEMO_SRV.Address"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "4XX": {
-                        "$ref": "#/components/responses/error"
-                    }
-                }
-            }
-        },
         "/$batch": {
             "post": {
                 "summary": "Send a group of requests",

--- a/tools/tests/addressable-v2.openapi3.json
+++ b/tools/tests/addressable-v2.openapi3.json
@@ -364,6 +364,75 @@
                 }
             }
         },
+        "/AddressSet(BusinessPartner='{BusinessPartner}',AddressId='{AddressId}')": {
+            "parameters": [
+                {
+                    "name": "BusinessPartner",
+                    "in": "path",
+                    "required": true,
+                    "description": "Geschäftspartnernummer",
+                    "schema": {
+                        "type": "string",
+                        "maxLength": 10
+                    }
+                },
+                {
+                    "name": "AddressId",
+                    "in": "path",
+                    "required": true,
+                    "description": "Adressnummer",
+                    "schema": {
+                        "type": "string",
+                        "maxLength": 10
+                    }
+                }
+            ],
+            "patch": {
+                "summary": "Update entity in AddressSet",
+                "tags": [
+                    "AddressSet"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "description": "New property values",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "title": "Modified Address",
+                                "type": "object",
+                                "properties": {
+                                    "d": {
+                                        "$ref": "#/components/schemas/ZE_API_DEMO_SRV.Address-update"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "204": {
+                        "description": "Success"
+                    },
+                    "4XX": {
+                        "$ref": "#/components/responses/error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete entity from AddressSet",
+                "tags": [
+                    "AddressSet"
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Success"
+                    },
+                    "4XX": {
+                        "$ref": "#/components/responses/error"
+                    }
+                }
+            }
+        },
         "/$batch": {
             "post": {
                 "summary": "Send a group of requests",

--- a/tools/tests/addressable-v2.swagger.json
+++ b/tools/tests/addressable-v2.swagger.json
@@ -1,0 +1,700 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "title": "Service for namespace ZE_API_DEMO_SRV",
+        "version": "",
+        "description": "This service is located at [https://localhost/service-root/](https://localhost/service-root/)\n\n## Entity Data Model\n![ER Diagram](https://yuml.me/diagram/class/[Head{bg:orange}],[Head]-*>[Address{bg:orange}],[Address{bg:orange}],[HeadSet{bg:dodgerblue}]++-*>[Head],[AddressSet{bg:dodgerblue}]++-*>[Address])\n\n### Legend\n![Legend](https://yuml.me/diagram/plain;dir:TB;scale:60/class/[External.Type{bg:whitesmoke}],[ComplexType],[EntityType{bg:orange}],[EntitySet/Singleton/Operation{bg:dodgerblue}])"
+    },
+    "schemes": [
+        "https"
+    ],
+    "host": "localhost",
+    "basePath": "/service-root",
+    "consumes": [
+        "application/json"
+    ],
+    "produces": [
+        "application/json"
+    ],
+    "tags": [
+        {
+            "name": "HeadSet"
+        },
+        {
+            "name": "AddressSet"
+        }
+    ],
+    "paths": {
+        "/HeadSet": {
+            "get": {
+                "summary": "Get entities from HeadSet",
+                "tags": [
+                    "HeadSet"
+                ],
+                "parameters": [
+                    {
+                        "name": "$filter",
+                        "in": "query",
+                        "description": "Filter items by property values, see [Filtering](https://help.sap.com/doc/5890d27be418427993fafa6722cdc03b/Cloud/en-US/OdataV2.pdf#page=64)",
+                        "type": "string"
+                    },
+                    {
+                        "$ref": "#/parameters/count"
+                    },
+                    {
+                        "name": "$select",
+                        "in": "query",
+                        "description": "Select properties to be returned, see [Select](https://help.sap.com/doc/5890d27be418427993fafa6722cdc03b/Cloud/en-US/OdataV2.pdf#page=68)",
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "string",
+                            "enum": [
+                                "BusinessPartner",
+                                "Type",
+                                "Grouping",
+                                "Title",
+                                "FirstName",
+                                "LastName",
+                                "IsBlocked",
+                                "ETag",
+                                "to_Address"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "$expand",
+                        "in": "query",
+                        "description": "Expand related entities, see [Expand](https://help.sap.com/doc/5890d27be418427993fafa6722cdc03b/Cloud/en-US/OdataV2.pdf#page=63)",
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "string",
+                            "enum": [
+                                "to_Address"
+                            ]
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Retrieved entities",
+                        "schema": {
+                            "title": "Wrapper",
+                            "type": "object",
+                            "properties": {
+                                "d": {
+                                    "title": "Collection of Head",
+                                    "type": "object",
+                                    "properties": {
+                                        "__count": {
+                                            "$ref": "#/definitions/count"
+                                        },
+                                        "results": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/ZE_API_DEMO_SRV.Head"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "$ref": "#/responses/error"
+                    }
+                }
+            },
+            "post": {
+                "summary": "Add new entity to HeadSet",
+                "tags": [
+                    "HeadSet"
+                ],
+                "parameters": [
+                    {
+                        "name": "Head",
+                        "in": "body",
+                        "description": "New entity",
+                        "schema": {
+                            "$ref": "#/definitions/ZE_API_DEMO_SRV.Head-create"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created entity",
+                        "schema": {
+                            "title": "Head",
+                            "type": "object",
+                            "properties": {
+                                "d": {
+                                    "$ref": "#/definitions/ZE_API_DEMO_SRV.Head"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "$ref": "#/responses/error"
+                    }
+                }
+            }
+        },
+        "/HeadSet('{BusinessPartner}')": {
+            "parameters": [
+                {
+                    "name": "BusinessPartner",
+                    "in": "path",
+                    "required": true,
+                    "description": "Geschäftspartnernummer",
+                    "type": "string"
+                }
+            ],
+            "get": {
+                "summary": "Get entity from HeadSet by key",
+                "tags": [
+                    "HeadSet"
+                ],
+                "parameters": [
+                    {
+                        "name": "$select",
+                        "in": "query",
+                        "description": "Select properties to be returned, see [Select](https://help.sap.com/doc/5890d27be418427993fafa6722cdc03b/Cloud/en-US/OdataV2.pdf#page=68)",
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "string",
+                            "enum": [
+                                "BusinessPartner",
+                                "Type",
+                                "Grouping",
+                                "Title",
+                                "FirstName",
+                                "LastName",
+                                "IsBlocked",
+                                "ETag",
+                                "to_Address"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "$expand",
+                        "in": "query",
+                        "description": "Expand related entities, see [Expand](https://help.sap.com/doc/5890d27be418427993fafa6722cdc03b/Cloud/en-US/OdataV2.pdf#page=63)",
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "string",
+                            "enum": [
+                                "to_Address"
+                            ]
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Retrieved entity",
+                        "schema": {
+                            "title": "Head",
+                            "type": "object",
+                            "properties": {
+                                "d": {
+                                    "$ref": "#/definitions/ZE_API_DEMO_SRV.Head"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "$ref": "#/responses/error"
+                    }
+                }
+            }
+        },
+        "/HeadSet('{BusinessPartner}')/to_Address": {
+            "parameters": [
+                {
+                    "name": "BusinessPartner",
+                    "in": "path",
+                    "required": true,
+                    "description": "Geschäftspartnernummer",
+                    "type": "string"
+                }
+            ],
+            "get": {
+                "summary": "Get entities from related to_Address",
+                "tags": [
+                    "HeadSet",
+                    "AddressSet"
+                ],
+                "parameters": [
+                    {
+                        "name": "$filter",
+                        "in": "query",
+                        "description": "Filter items by property values, see [Filtering](https://help.sap.com/doc/5890d27be418427993fafa6722cdc03b/Cloud/en-US/OdataV2.pdf#page=64)",
+                        "type": "string"
+                    },
+                    {
+                        "$ref": "#/parameters/count"
+                    },
+                    {
+                        "name": "$select",
+                        "in": "query",
+                        "description": "Select properties to be returned, see [Select](https://help.sap.com/doc/5890d27be418427993fafa6722cdc03b/Cloud/en-US/OdataV2.pdf#page=68)",
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "string",
+                            "enum": [
+                                "BusinessPartner",
+                                "AddressId",
+                                "District",
+                                "Street",
+                                "HouseNumber",
+                                "PostalCode",
+                                "City",
+                                "Country",
+                                "ETag"
+                            ]
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Retrieved entities",
+                        "schema": {
+                            "title": "Wrapper",
+                            "type": "object",
+                            "properties": {
+                                "d": {
+                                    "title": "Collection of Address",
+                                    "type": "object",
+                                    "properties": {
+                                        "__count": {
+                                            "$ref": "#/definitions/count"
+                                        },
+                                        "results": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/ZE_API_DEMO_SRV.Address"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "$ref": "#/responses/error"
+                    }
+                }
+            },
+            "post": {
+                "summary": "Add new entity to related to_Address",
+                "tags": [
+                    "HeadSet",
+                    "AddressSet"
+                ],
+                "parameters": [
+                    {
+                        "name": "Address",
+                        "in": "body",
+                        "description": "New entity",
+                        "schema": {
+                            "$ref": "#/definitions/ZE_API_DEMO_SRV.Address-create"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created entity",
+                        "schema": {
+                            "title": "Address",
+                            "type": "object",
+                            "properties": {
+                                "d": {
+                                    "$ref": "#/definitions/ZE_API_DEMO_SRV.Address"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "$ref": "#/responses/error"
+                    }
+                }
+            }
+        },
+        "/AddressSet(BusinessPartner='{BusinessPartner}',AddressId='{AddressId}')": {
+            "parameters": [
+                {
+                    "name": "BusinessPartner",
+                    "in": "path",
+                    "required": true,
+                    "description": "Geschäftspartnernummer",
+                    "type": "string"
+                },
+                {
+                    "name": "AddressId",
+                    "in": "path",
+                    "required": true,
+                    "description": "Adressnummer",
+                    "type": "string"
+                }
+            ],
+            "patch": {
+                "summary": "Update entity in AddressSet",
+                "tags": [
+                    "AddressSet"
+                ],
+                "parameters": [
+                    {
+                        "name": "Address",
+                        "in": "body",
+                        "description": "New property values",
+                        "schema": {
+                            "title": "Modified Address",
+                            "type": "object",
+                            "properties": {
+                                "d": {
+                                    "$ref": "#/definitions/ZE_API_DEMO_SRV.Address-update"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Success"
+                    },
+                    "400": {
+                        "$ref": "#/responses/error"
+                    }
+                }
+            },
+            "delete": {
+                "summary": "Delete entity from AddressSet",
+                "tags": [
+                    "AddressSet"
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Success"
+                    },
+                    "400": {
+                        "$ref": "#/responses/error"
+                    }
+                }
+            }
+        },
+        "/$batch": {
+            "post": {
+                "summary": "Send a group of requests",
+                "description": "Group multiple requests into a single request payload, see [Batch Requests](https://help.sap.com/doc/5890d27be418427993fafa6722cdc03b/Cloud/en-US/OdataV2.pdf#page=152).",
+                "tags": [
+                    "Batch Requests"
+                ],
+                "consumes": [
+                    "multipart/mixed;boundary=request-separator"
+                ],
+                "produces": [
+                    "multipart/mixed"
+                ],
+                "parameters": [
+                    {
+                        "name": "requestBody",
+                        "in": "body",
+                        "description": "Batch request",
+                        "schema": {
+                            "type": "string",
+                            "example": "--request-separator\nContent-Type: application/http\nContent-Transfer-Encoding: binary\n\nGET HeadSet HTTP/1.1\nAccept: application/json\n\n\n--request-separator--"
+                        }
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Batch response",
+                        "schema": {
+                            "type": "string",
+                            "example": "--response-separator\nContent-Type: application/http\n\nHTTP/1.1 200 OK\nContent-Type: application/json\n\n{...}\n--response-separator--"
+                        }
+                    },
+                    "400": {
+                        "$ref": "#/responses/error"
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "ZE_API_DEMO_SRV.Head": {
+            "type": "object",
+            "properties": {
+                "BusinessPartner": {
+                    "type": "string",
+                    "maxLength": 10,
+                    "title": "GeschPartner",
+                    "description": "Geschäftspartnernummer"
+                },
+                "Type": {
+                    "type": "string",
+                    "maxLength": 4,
+                    "title": "Partnerart",
+                    "description": "Geschäftspartnerart"
+                },
+                "Grouping": {
+                    "type": "string",
+                    "maxLength": 4,
+                    "title": "Gruppierung",
+                    "description": "Geschäftspartnergruppierung"
+                },
+                "Title": {
+                    "type": "string",
+                    "maxLength": 4,
+                    "title": "Anrede",
+                    "description": "Anredeschlüssel"
+                },
+                "FirstName": {
+                    "type": "string",
+                    "maxLength": 40,
+                    "title": "Vorname",
+                    "description": "Vorname des Geschäftspartners (Person)"
+                },
+                "LastName": {
+                    "type": "string",
+                    "maxLength": 40,
+                    "title": "Nachname",
+                    "description": "Nachname des Geschäftspartners (Person)"
+                },
+                "IsBlocked": {
+                    "type": "boolean",
+                    "title": "Zentrale Sperre",
+                    "description": "Zentrale Sperre für den Geschäftspartner"
+                },
+                "ETag": {
+                    "type": "string",
+                    "maxLength": 40,
+                    "title": "Hash-Wert",
+                    "description": "Hash-Wert (160 Bits)"
+                },
+                "to_Address": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ZE_API_DEMO_SRV.Address"
+                            }
+                        }
+                    }
+                }
+            },
+            "title": "Head"
+        },
+        "ZE_API_DEMO_SRV.Head-create": {
+            "type": "object",
+            "properties": {
+                "Title": {
+                    "type": "string",
+                    "maxLength": 4,
+                    "title": "Anrede",
+                    "description": "Anredeschlüssel"
+                },
+                "FirstName": {
+                    "type": "string",
+                    "maxLength": 40,
+                    "title": "Vorname",
+                    "description": "Vorname des Geschäftspartners (Person)"
+                },
+                "LastName": {
+                    "type": "string",
+                    "maxLength": 40,
+                    "title": "Nachname",
+                    "description": "Nachname des Geschäftspartners (Person)"
+                },
+                "to_Address": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ZE_API_DEMO_SRV.Address-create"
+                            }
+                        }
+                    }
+                }
+            },
+            "title": "Head (for create)"
+        },
+        "ZE_API_DEMO_SRV.Head-update": {
+            "type": "object",
+            "title": "Head (for update)"
+        },
+        "ZE_API_DEMO_SRV.Address": {
+            "type": "object",
+            "properties": {
+                "BusinessPartner": {
+                    "type": "string",
+                    "maxLength": 10,
+                    "title": "GeschPartner",
+                    "description": "Geschäftspartnernummer"
+                },
+                "AddressId": {
+                    "type": "string",
+                    "maxLength": 10,
+                    "title": "Adressnummer"
+                },
+                "District": {
+                    "type": "string",
+                    "maxLength": 40,
+                    "title": "Ortsteil"
+                },
+                "Street": {
+                    "type": "string",
+                    "maxLength": 60,
+                    "title": "Straße"
+                },
+                "HouseNumber": {
+                    "type": "string",
+                    "maxLength": 10,
+                    "title": "Hausnummer"
+                },
+                "PostalCode": {
+                    "type": "string",
+                    "maxLength": 10,
+                    "title": "Postleitzahl",
+                    "description": "Postleitzahl des Orts"
+                },
+                "City": {
+                    "type": "string",
+                    "maxLength": 40,
+                    "title": "Ort"
+                },
+                "Country": {
+                    "type": "string",
+                    "maxLength": 2,
+                    "title": "ISO-Code",
+                    "description": "ISO-Code des Landes"
+                },
+                "ETag": {
+                    "type": "string",
+                    "maxLength": 40,
+                    "title": "Hash-Wert",
+                    "description": "Hash-Wert (160 Bits)"
+                }
+            },
+            "title": "Address"
+        },
+        "ZE_API_DEMO_SRV.Address-create": {
+            "type": "object",
+            "properties": {
+                "District": {
+                    "type": "string",
+                    "maxLength": 40,
+                    "title": "Ortsteil"
+                },
+                "Street": {
+                    "type": "string",
+                    "maxLength": 60,
+                    "title": "Straße"
+                },
+                "HouseNumber": {
+                    "type": "string",
+                    "maxLength": 10,
+                    "title": "Hausnummer"
+                },
+                "PostalCode": {
+                    "type": "string",
+                    "maxLength": 10,
+                    "title": "Postleitzahl",
+                    "description": "Postleitzahl des Orts"
+                },
+                "City": {
+                    "type": "string",
+                    "maxLength": 40,
+                    "title": "Ort"
+                }
+            },
+            "title": "Address (for create)"
+        },
+        "ZE_API_DEMO_SRV.Address-update": {
+            "type": "object",
+            "title": "Address (for update)"
+        },
+        "count": {
+            "type": "string",
+            "description": "The number of entities in the collection. Available when using the [$inlinecount](https://help.sap.com/doc/5890d27be418427993fafa6722cdc03b/Cloud/en-US/OdataV2.pdf#page=67) query option."
+        },
+        "error": {
+            "type": "object",
+            "required": [
+                "error"
+            ],
+            "properties": {
+                "error": {
+                    "type": "object",
+                    "required": [
+                        "code",
+                        "message"
+                    ],
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "message": {
+                            "type": "object",
+                            "required": [
+                                "lang",
+                                "value"
+                            ],
+                            "properties": {
+                                "lang": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "innererror": {
+                            "type": "object",
+                            "description": "The structure of this object is service-specific"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "parameters": {
+        "top": {
+            "name": "$top",
+            "in": "query",
+            "description": "Show only the first n items, see [Paging - Top](https://help.sap.com/doc/5890d27be418427993fafa6722cdc03b/Cloud/en-US/OdataV2.pdf#page=66)",
+            "type": "integer",
+            "minimum": 0
+        },
+        "skip": {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skip the first n items, see [Paging - Skip](https://help.sap.com/doc/5890d27be418427993fafa6722cdc03b/Cloud/en-US/OdataV2.pdf#page=65)",
+            "type": "integer",
+            "minimum": 0
+        },
+        "count": {
+            "name": "$inlinecount",
+            "in": "query",
+            "description": "Include count of items, see [Inlinecount](https://help.sap.com/doc/5890d27be418427993fafa6722cdc03b/Cloud/en-US/OdataV2.pdf#page=67)",
+            "type": "string",
+            "enum": [
+                "allpages",
+                "none"
+            ]
+        }
+    },
+    "responses": {
+        "error": {
+            "description": "Error",
+            "schema": {
+                "$ref": "#/definitions/error"
+            }
+        }
+    }
+}

--- a/tools/tests/addressable-v2.xml
+++ b/tools/tests/addressable-v2.xml
@@ -99,11 +99,9 @@
         sap:supported-formats="atom json xlsx">
         <EntitySet Name="HeadSet" EntityType="ZE_API_DEMO_SRV.Head" sap:updatable="false"
           sap:deletable="false" sap:pageable="false" sap:content-version="1" />
-        <EntitySet Name="AddressSet" EntityType="ZE_API_DEMO_SRV.Address"
-          sap:updatable="false" sap:deletable="false" sap:pageable="false"
+        <EntitySet Name="AddressSet" EntityType="ZE_API_DEMO_SRV.Address" sap:pageable="false"
           sap:addressable="false" sap:content-version="1" />
         <AssociationSet Name="to_AddressSet" Association="ZE_API_DEMO_SRV.to_Address"
-          sap:creatable="false" sap:updatable="false" sap:deletable="false"
           sap:content-version="1">
           <End EntitySet="HeadSet" Role="FromRole_to_Address" />
           <End EntitySet="AddressSet" Role="ToRole_to_Address" />

--- a/tools/tests/addressable-v2.xml
+++ b/tools/tests/addressable-v2.xml
@@ -1,0 +1,114 @@
+<edmx:Edmx xmlns:edmx="http://schemas.microsoft.com/ado/2007/06/edmx"
+  xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata"
+  xmlns:sap="http://www.sap.com/Protocols/SAPData" Version="1.0">
+  <edmx:DataServices m:DataServiceVersion="2.0">
+    <Schema xmlns="http://schemas.microsoft.com/ado/2008/09/edm" Namespace="ZE_API_DEMO_SRV"
+      xml:lang="de" sap:schema-version="1">
+      <EntityType Name="Head" sap:content-version="1">
+        <Key>
+          <PropertyRef Name="BusinessPartner" />
+        </Key>
+        <Property Name="BusinessPartner" Type="Edm.String" Nullable="false" MaxLength="10"
+          sap:unicode="false" sap:label="GeschPartner" sap:heading="Geschäftspartner"
+          sap:quickinfo="Geschäftspartnernummer" sap:creatable="false"
+          sap:updatable="false" sap:sortable="false" sap:filterable="false" />
+        <Property Name="Type" Type="Edm.String" Nullable="false" MaxLength="4"
+          sap:unicode="false" sap:label="Partnerart" sap:heading="Art"
+          sap:quickinfo="Geschäftspartnerart" sap:creatable="false" sap:updatable="false"
+          sap:sortable="false" sap:filterable="false"></Property>
+        <Property Name="Grouping" Type="Edm.String" Nullable="false" MaxLength="4"
+          sap:unicode="false" sap:label="Gruppierung" sap:heading="Grp."
+          sap:quickinfo="Geschäftspartnergruppierung" sap:creatable="false"
+          sap:updatable="false" sap:sortable="false" sap:filterable="false"></Property>
+        <Property Name="Title" Type="Edm.String" Nullable="false" MaxLength="4"
+          sap:unicode="false" sap:label="Anrede" sap:heading="Schlüssel"
+          sap:quickinfo="Anredeschlüssel" sap:updatable="false" sap:sortable="false"
+          sap:filterable="false"></Property>
+        <Property Name="FirstName" Type="Edm.String" Nullable="false" MaxLength="40"
+          sap:unicode="false" sap:label="Vorname"
+          sap:quickinfo="Vorname des Geschäftspartners (Person)" sap:updatable="false"
+          sap:sortable="false" sap:filterable="false" />
+        <Property Name="LastName" Type="Edm.String" Nullable="false" MaxLength="40"
+          sap:unicode="false" sap:label="Nachname"
+          sap:quickinfo="Nachname des Geschäftspartners (Person)" sap:updatable="false"
+          sap:sortable="false" sap:filterable="false" />
+        <Property Name="IsBlocked" Type="Edm.Boolean" Nullable="false" sap:unicode="false"
+          sap:label="Zentrale Sperre"
+          sap:quickinfo="Zentrale Sperre für den Geschäftspartner" sap:creatable="false"
+          sap:updatable="false" sap:sortable="false" sap:filterable="false"></Property>
+        <Property Name="ETag" Type="Edm.String" Nullable="false" MaxLength="40"
+          ConcurrencyMode="Fixed" sap:unicode="false" sap:label="Hash-Wert"
+          sap:heading="Hash-Wert (160 Bits)" sap:quickinfo="Hash-Wert (160 Bits)"
+          sap:creatable="false" sap:updatable="false" sap:sortable="false"
+          sap:filterable="false" />
+        <NavigationProperty Name="to_Address" Relationship="ZE_API_DEMO_SRV.to_Address"
+          FromRole="FromRole_to_Address" ToRole="ToRole_to_Address" />
+      </EntityType>
+      <EntityType Name="Address" sap:content-version="1">
+        <Key>
+          <PropertyRef Name="BusinessPartner" />
+          <PropertyRef Name="AddressId" />
+        </Key>
+        <Property Name="BusinessPartner" Type="Edm.String" Nullable="false" MaxLength="10"
+          sap:unicode="false" sap:label="GeschPartner" sap:heading="Geschäftspartner"
+          sap:quickinfo="Geschäftspartnernummer" sap:creatable="false"
+          sap:updatable="false" sap:sortable="false" sap:filterable="false"></Property>
+        <Property Name="AddressId" Type="Edm.String" Nullable="false" MaxLength="10"
+          sap:unicode="false" sap:label="Adressnummer" sap:heading="Adressnum."
+          sap:creatable="false" sap:updatable="false" sap:sortable="false"
+          sap:filterable="false"></Property>
+        <Property Name="District" Type="Edm.String" Nullable="false" MaxLength="40"
+          sap:unicode="false" sap:label="Ortsteil" sap:updatable="false"
+          sap:sortable="false" sap:filterable="false"></Property>
+        <Property Name="Street" Type="Edm.String" Nullable="false" MaxLength="60"
+          sap:unicode="false" sap:label="Straße" sap:updatable="false"
+          sap:sortable="false" sap:filterable="false"></Property>
+        <Property Name="HouseNumber" Type="Edm.String" Nullable="false" MaxLength="10"
+          sap:unicode="false" sap:label="Hausnummer" sap:updatable="false"
+          sap:sortable="false" sap:filterable="false"></Property>
+        <Property Name="PostalCode" Type="Edm.String" Nullable="false" MaxLength="10"
+          sap:unicode="false" sap:label="Postleitzahl" sap:heading="PLZ"
+          sap:quickinfo="Postleitzahl des Orts" sap:updatable="false" sap:sortable="false"
+          sap:filterable="false"></Property>
+        <Property Name="City" Type="Edm.String" Nullable="false" MaxLength="40"
+          sap:unicode="false" sap:label="Ort" sap:updatable="false" sap:sortable="false"
+          sap:filterable="false"></Property>
+        <Property Name="Country" Type="Edm.String" Nullable="false" MaxLength="2"
+          sap:unicode="false" sap:label="ISO-Code" sap:quickinfo="ISO-Code des Landes"
+          sap:creatable="false" sap:updatable="false" sap:sortable="false"
+          sap:filterable="false"></Property>
+        <Property Name="ETag" Type="Edm.String" Nullable="false" MaxLength="40"
+          ConcurrencyMode="Fixed" sap:unicode="false" sap:label="Hash-Wert"
+          sap:heading="Hash-Wert (160 Bits)" sap:quickinfo="Hash-Wert (160 Bits)"
+          sap:creatable="false" sap:updatable="false" sap:sortable="false"
+          sap:filterable="false" />
+      </EntityType>
+      <Association Name="to_Address" sap:content-version="1">
+        <End Type="ZE_API_DEMO_SRV.Head" Multiplicity="1" Role="FromRole_to_Address" />
+        <End Type="ZE_API_DEMO_SRV.Address" Multiplicity="*" Role="ToRole_to_Address" />
+        <ReferentialConstraint>
+          <Principal Role="FromRole_to_Address">
+            <PropertyRef Name="BusinessPartner" />
+          </Principal>
+          <Dependent Role="ToRole_to_Address">
+            <PropertyRef Name="BusinessPartner" />
+          </Dependent>
+        </ReferentialConstraint>
+      </Association>
+      <EntityContainer Name="ZE_API_DEMO_SRV_Entities" m:IsDefaultEntityContainer="true"
+        sap:supported-formats="atom json xlsx">
+        <EntitySet Name="HeadSet" EntityType="ZE_API_DEMO_SRV.Head" sap:updatable="false"
+          sap:deletable="false" sap:pageable="false" sap:content-version="1" />
+        <EntitySet Name="AddressSet" EntityType="ZE_API_DEMO_SRV.Address"
+          sap:updatable="false" sap:deletable="false" sap:pageable="false"
+          sap:addressable="false" sap:content-version="1" />
+        <AssociationSet Name="to_AddressSet" Association="ZE_API_DEMO_SRV.to_Address"
+          sap:creatable="false" sap:updatable="false" sap:deletable="false"
+          sap:content-version="1">
+          <End EntitySet="HeadSet" Role="FromRole_to_Address" />
+          <End EntitySet="AddressSet" Role="ToRole_to_Address" />
+        </AssociationSet>
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/tools/tests/addressable-v2.xml
+++ b/tools/tests/addressable-v2.xml
@@ -15,15 +15,15 @@
         <Property Name="Type" Type="Edm.String" Nullable="false" MaxLength="4"
           sap:unicode="false" sap:label="Partnerart" sap:heading="Art"
           sap:quickinfo="Geschäftspartnerart" sap:creatable="false" sap:updatable="false"
-          sap:sortable="false" sap:filterable="false"></Property>
+          sap:sortable="false" sap:filterable="false" />
         <Property Name="Grouping" Type="Edm.String" Nullable="false" MaxLength="4"
           sap:unicode="false" sap:label="Gruppierung" sap:heading="Grp."
           sap:quickinfo="Geschäftspartnergruppierung" sap:creatable="false"
-          sap:updatable="false" sap:sortable="false" sap:filterable="false"></Property>
+          sap:updatable="false" sap:sortable="false" sap:filterable="false" />
         <Property Name="Title" Type="Edm.String" Nullable="false" MaxLength="4"
           sap:unicode="false" sap:label="Anrede" sap:heading="Schlüssel"
           sap:quickinfo="Anredeschlüssel" sap:updatable="false" sap:sortable="false"
-          sap:filterable="false"></Property>
+          sap:filterable="false" />
         <Property Name="FirstName" Type="Edm.String" Nullable="false" MaxLength="40"
           sap:unicode="false" sap:label="Vorname"
           sap:quickinfo="Vorname des Geschäftspartners (Person)" sap:updatable="false"
@@ -35,7 +35,7 @@
         <Property Name="IsBlocked" Type="Edm.Boolean" Nullable="false" sap:unicode="false"
           sap:label="Zentrale Sperre"
           sap:quickinfo="Zentrale Sperre für den Geschäftspartner" sap:creatable="false"
-          sap:updatable="false" sap:sortable="false" sap:filterable="false"></Property>
+          sap:updatable="false" sap:sortable="false" sap:filterable="false" />
         <Property Name="ETag" Type="Edm.String" Nullable="false" MaxLength="40"
           ConcurrencyMode="Fixed" sap:unicode="false" sap:label="Hash-Wert"
           sap:heading="Hash-Wert (160 Bits)" sap:quickinfo="Hash-Wert (160 Bits)"
@@ -52,31 +52,31 @@
         <Property Name="BusinessPartner" Type="Edm.String" Nullable="false" MaxLength="10"
           sap:unicode="false" sap:label="GeschPartner" sap:heading="Geschäftspartner"
           sap:quickinfo="Geschäftspartnernummer" sap:creatable="false"
-          sap:updatable="false" sap:sortable="false" sap:filterable="false"></Property>
+          sap:updatable="false" sap:sortable="false" sap:filterable="false" />
         <Property Name="AddressId" Type="Edm.String" Nullable="false" MaxLength="10"
           sap:unicode="false" sap:label="Adressnummer" sap:heading="Adressnum."
           sap:creatable="false" sap:updatable="false" sap:sortable="false"
-          sap:filterable="false"></Property>
+          sap:filterable="false" />
         <Property Name="District" Type="Edm.String" Nullable="false" MaxLength="40"
           sap:unicode="false" sap:label="Ortsteil" sap:updatable="false"
-          sap:sortable="false" sap:filterable="false"></Property>
+          sap:sortable="false" sap:filterable="false" />
         <Property Name="Street" Type="Edm.String" Nullable="false" MaxLength="60"
           sap:unicode="false" sap:label="Straße" sap:updatable="false"
-          sap:sortable="false" sap:filterable="false"></Property>
+          sap:sortable="false" sap:filterable="false" />
         <Property Name="HouseNumber" Type="Edm.String" Nullable="false" MaxLength="10"
           sap:unicode="false" sap:label="Hausnummer" sap:updatable="false"
-          sap:sortable="false" sap:filterable="false"></Property>
+          sap:sortable="false" sap:filterable="false" />
         <Property Name="PostalCode" Type="Edm.String" Nullable="false" MaxLength="10"
           sap:unicode="false" sap:label="Postleitzahl" sap:heading="PLZ"
           sap:quickinfo="Postleitzahl des Orts" sap:updatable="false" sap:sortable="false"
-          sap:filterable="false"></Property>
+          sap:filterable="false" />
         <Property Name="City" Type="Edm.String" Nullable="false" MaxLength="40"
           sap:unicode="false" sap:label="Ort" sap:updatable="false" sap:sortable="false"
-          sap:filterable="false"></Property>
+          sap:filterable="false" />
         <Property Name="Country" Type="Edm.String" Nullable="false" MaxLength="2"
           sap:unicode="false" sap:label="ISO-Code" sap:quickinfo="ISO-Code des Landes"
           sap:creatable="false" sap:updatable="false" sap:sortable="false"
-          sap:filterable="false"></Property>
+          sap:filterable="false" />
         <Property Name="ETag" Type="Edm.String" Nullable="false" MaxLength="40"
           ConcurrencyMode="Fixed" sap:unicode="false" sap:label="Hash-Wert"
           sap:heading="Hash-Wert (160 Bits)" sap:quickinfo="Hash-Wert (160 Bits)"


### PR DESCRIPTION
Fixes #311 

- [x] If entity set `Foo` is not addressable, no `post` operation for path `/Foo` will be generated
- [x] If it is creatable, a `post` operation for path `/Parent(...)/to_Foo` will be generated
- [x] If it is updatable or deletable, `patch` or `delete` will be generated as usual for path `/Foo(...)`

Plus
- [x] Remove leftover from unsuccessful experiment