### PR TITLE
Key fields not required

### DIFF
--- a/tools/V4-CSDL-to-OpenAPI.xsl
+++ b/tools/V4-CSDL-to-OpenAPI.xsl
@@ -1556,10 +1556,9 @@
     </xsl:variable>
     <xsl:variable name="required">
       <xsl:if test="$suffix='-create'">
-        <!-- non-computed key properties are required, as are properties marked with Common.FieldControl=Mandatory -->
+        <!-- properties are required if marked with Common.FieldControl=Mandatory -->
         <xsl:for-each select="$structuredType/edm:Property[
-          (@Name=../edm:Key/edm:PropertyRef/@Name and not(@Name=$read-only or @Name=$computed or concat($qualifiedName,'/',@Name) = $computed-ext or concat($aliasQualifiedName,'/',@Name) = $computed-ext)) 
-          or concat($qualifiedName,'/',@Name)=$mandatory or concat($aliasQualifiedName,'/',@Name)=$mandatory]">
+          concat($qualifiedName,'/',@Name)=$mandatory or concat($aliasQualifiedName,'/',@Name)=$mandatory]">
           <xsl:if test="position()>1">
             <xsl:text>,</xsl:text>
           </xsl:if>

--- a/tools/tests/Northwind-key-as-segment.openapi3.json
+++ b/tools/tests/Northwind-key-as-segment.openapi3.json
@@ -10355,9 +10355,6 @@
                         }
                     }
                 },
-                "required": [
-                    "CategoryID"
-                ],
                 "title": "Category (for create)"
             },
             "NorthwindModel.Category-update": {
@@ -10417,9 +10414,6 @@
                         }
                     }
                 },
-                "required": [
-                    "CustomerTypeID"
-                ],
                 "title": "CustomerDemographic (for create)"
             },
             "NorthwindModel.CustomerDemographic-update": {
@@ -10572,9 +10566,6 @@
                         }
                     }
                 },
-                "required": [
-                    "CustomerID"
-                ],
                 "title": "Customer (for create)"
             },
             "NorthwindModel.Customer-update": {
@@ -10870,9 +10861,6 @@
                         }
                     }
                 },
-                "required": [
-                    "EmployeeID"
-                ],
                 "title": "Employee (for create)"
             },
             "NorthwindModel.Employee-update": {
@@ -11065,10 +11053,6 @@
                         "$ref": "#/components/schemas/NorthwindModel.Product-create"
                     }
                 },
-                "required": [
-                    "OrderID",
-                    "ProductID"
-                ],
                 "title": "Order_Detail (for create)"
             },
             "NorthwindModel.Order_Detail-update": {
@@ -11344,9 +11328,6 @@
                         ]
                     }
                 },
-                "required": [
-                    "OrderID"
-                ],
                 "title": "Order (for create)"
             },
             "NorthwindModel.Order-update": {
@@ -11602,9 +11583,6 @@
                         ]
                     }
                 },
-                "required": [
-                    "ProductID"
-                ],
                 "title": "Product (for create)"
             },
             "NorthwindModel.Product-update": {
@@ -11704,9 +11682,6 @@
                         }
                     }
                 },
-                "required": [
-                    "RegionID"
-                ],
                 "title": "Region (for create)"
             },
             "NorthwindModel.Region-update": {
@@ -11767,9 +11742,6 @@
                         }
                     }
                 },
-                "required": [
-                    "ShipperID"
-                ],
                 "title": "Shipper (for create)"
             },
             "NorthwindModel.Shipper-update": {
@@ -11923,9 +11895,6 @@
                         }
                     }
                 },
-                "required": [
-                    "SupplierID"
-                ],
                 "title": "Supplier (for create)"
             },
             "NorthwindModel.Supplier-update": {
@@ -12039,9 +12008,6 @@
                         }
                     }
                 },
-                "required": [
-                    "TerritoryID"
-                ],
                 "title": "Territory (for create)"
             },
             "NorthwindModel.Territory-update": {
@@ -12190,12 +12156,6 @@
                         "maxLength": 15
                     }
                 },
-                "required": [
-                    "ProductID",
-                    "ProductName",
-                    "Discontinued",
-                    "CategoryName"
-                ],
                 "title": "Alphabetical_list_of_product (for create)"
             },
             "NorthwindModel.Alphabetical_list_of_product-update": {
@@ -12300,9 +12260,6 @@
                         "example": 0
                     }
                 },
-                "required": [
-                    "CategoryName"
-                ],
                 "title": "Category_Sales_for_1997 (for create)"
             },
             "NorthwindModel.Category_Sales_for_1997-update": {
@@ -12353,10 +12310,6 @@
                         "maxLength": 40
                     }
                 },
-                "required": [
-                    "ProductID",
-                    "ProductName"
-                ],
                 "title": "Current_Product_List (for create)"
             },
             "NorthwindModel.Current_Product_List-update": {
@@ -12409,10 +12362,6 @@
                         "maxLength": 9
                     }
                 },
-                "required": [
-                    "CompanyName",
-                    "Relationship"
-                ],
                 "title": "Customer_and_Suppliers_by_City (for create)"
             },
             "NorthwindModel.Customer_and_Suppliers_by_City-update": {
@@ -12771,17 +12720,6 @@
                         "example": 0
                     }
                 },
-                "required": [
-                    "CustomerName",
-                    "Salesperson",
-                    "OrderID",
-                    "ShipperName",
-                    "ProductID",
-                    "ProductName",
-                    "UnitPrice",
-                    "Quantity",
-                    "Discount"
-                ],
                 "title": "Invoice (for create)"
             },
             "NorthwindModel.Invoice-update": {
@@ -13028,14 +12966,6 @@
                         "example": 0
                     }
                 },
-                "required": [
-                    "OrderID",
-                    "ProductID",
-                    "ProductName",
-                    "UnitPrice",
-                    "Quantity",
-                    "Discount"
-                ],
                 "title": "Order_Details_Extended (for create)"
             },
             "NorthwindModel.Order_Details_Extended-update": {
@@ -13110,9 +13040,6 @@
                         "example": 0
                     }
                 },
-                "required": [
-                    "OrderID"
-                ],
                 "title": "Order_Subtotal (for create)"
             },
             "NorthwindModel.Order_Subtotal-update": {
@@ -13371,10 +13298,6 @@
                         "maxLength": 15
                     }
                 },
-                "required": [
-                    "OrderID",
-                    "CompanyName"
-                ],
                 "title": "Orders_Qry (for create)"
             },
             "NorthwindModel.Orders_Qry-update": {
@@ -13545,10 +13468,6 @@
                         "example": 0
                     }
                 },
-                "required": [
-                    "CategoryName",
-                    "ProductName"
-                ],
                 "title": "Product_Sales_for_1997 (for create)"
             },
             "NorthwindModel.Product_Sales_for_1997-update": {
@@ -13623,9 +13542,6 @@
                         "example": 0
                     }
                 },
-                "required": [
-                    "ProductName"
-                ],
                 "title": "Products_Above_Average_Price (for create)"
             },
             "NorthwindModel.Products_Above_Average_Price-update": {
@@ -13702,11 +13618,6 @@
                         "type": "boolean"
                     }
                 },
-                "required": [
-                    "CategoryName",
-                    "ProductName",
-                    "Discontinued"
-                ],
                 "title": "Products_by_Category (for create)"
             },
             "NorthwindModel.Products_by_Category-update": {
@@ -13791,11 +13702,6 @@
                         "example": 0
                     }
                 },
-                "required": [
-                    "CategoryID",
-                    "CategoryName",
-                    "ProductName"
-                ],
                 "title": "Sales_by_Category (for create)"
             },
             "NorthwindModel.Sales_by_Category-update": {
@@ -13890,10 +13796,6 @@
                         "example": "2017-04-13T15:51:04Z"
                     }
                 },
-                "required": [
-                    "OrderID",
-                    "CompanyName"
-                ],
                 "title": "Sales_Totals_by_Amount (for create)"
             },
             "NorthwindModel.Sales_Totals_by_Amount-update": {
@@ -13986,9 +13888,6 @@
                         "example": 0
                     }
                 },
-                "required": [
-                    "OrderID"
-                ],
                 "title": "Summary_of_Sales_by_Quarter (for create)"
             },
             "NorthwindModel.Summary_of_Sales_by_Quarter-update": {
@@ -14081,9 +13980,6 @@
                         "example": 0
                     }
                 },
-                "required": [
-                    "OrderID"
-                ],
                 "title": "Summary_of_Sales_by_Year (for create)"
             },
             "NorthwindModel.Summary_of_Sales_by_Year-update": {

--- a/tools/tests/Northwind-key-as-segment.swagger.json
+++ b/tools/tests/Northwind-key-as-segment.swagger.json
@@ -8977,9 +8977,6 @@
                     }
                 }
             },
-            "required": [
-                "CategoryID"
-            ],
             "title": "Category (for create)"
         },
         "NorthwindModel.Category-update": {
@@ -9050,9 +9047,6 @@
                     }
                 }
             },
-            "required": [
-                "CustomerTypeID"
-            ],
             "title": "CustomerDemographic (for create)"
         },
         "NorthwindModel.CustomerDemographic-update": {
@@ -9262,9 +9256,6 @@
                     }
                 }
             },
-            "required": [
-                "CustomerID"
-            ],
             "title": "Customer (for create)"
         },
         "NorthwindModel.Customer-update": {
@@ -9659,9 +9650,6 @@
                     }
                 }
             },
-            "required": [
-                "EmployeeID"
-            ],
             "title": "Employee (for create)"
         },
         "NorthwindModel.Employee-update": {
@@ -9879,10 +9867,6 @@
                     "$ref": "#/definitions/NorthwindModel.Product-create"
                 }
             },
-            "required": [
-                "OrderID",
-                "ProductID"
-            ],
             "title": "Order_Detail (for create)"
         },
         "NorthwindModel.Order_Detail-update": {
@@ -10174,9 +10158,6 @@
                     "$ref": "#/definitions/NorthwindModel.Shipper-create"
                 }
             },
-            "required": [
-                "OrderID"
-            ],
             "title": "Order (for create)"
         },
         "NorthwindModel.Order-update": {
@@ -10457,9 +10438,6 @@
                     "$ref": "#/definitions/NorthwindModel.Supplier-create"
                 }
             },
-            "required": [
-                "ProductID"
-            ],
             "title": "Product (for create)"
         },
         "NorthwindModel.Product-update": {
@@ -10568,9 +10546,6 @@
                     }
                 }
             },
-            "required": [
-                "RegionID"
-            ],
             "title": "Region (for create)"
         },
         "NorthwindModel.Region-update": {
@@ -10637,9 +10612,6 @@
                     }
                 }
             },
-            "required": [
-                "ShipperID"
-            ],
             "title": "Shipper (for create)"
         },
         "NorthwindModel.Shipper-update": {
@@ -10856,9 +10828,6 @@
                     }
                 }
             },
-            "required": [
-                "SupplierID"
-            ],
             "title": "Supplier (for create)"
         },
         "NorthwindModel.Supplier-update": {
@@ -11002,9 +10971,6 @@
                     }
                 }
             },
-            "required": [
-                "TerritoryID"
-            ],
             "title": "Territory (for create)"
         },
         "NorthwindModel.Territory-update": {
@@ -11171,12 +11137,6 @@
                     "maxLength": 15
                 }
             },
-            "required": [
-                "ProductID",
-                "ProductName",
-                "Discontinued",
-                "CategoryName"
-            ],
             "title": "Alphabetical_list_of_product (for create)"
         },
         "NorthwindModel.Alphabetical_list_of_product-update": {
@@ -11282,9 +11242,6 @@
                     "example": 0
                 }
             },
-            "required": [
-                "CategoryName"
-            ],
             "title": "Category_Sales_for_1997 (for create)"
         },
         "NorthwindModel.Category_Sales_for_1997-update": {
@@ -11331,10 +11288,6 @@
                     "maxLength": 40
                 }
             },
-            "required": [
-                "ProductID",
-                "ProductName"
-            ],
             "title": "Current_Product_List (for create)"
         },
         "NorthwindModel.Current_Product_List-update": {
@@ -11399,10 +11352,6 @@
                     "maxLength": 9
                 }
             },
-            "required": [
-                "CompanyName",
-                "Relationship"
-            ],
             "title": "Customer_and_Suppliers_by_City (for create)"
         },
         "NorthwindModel.Customer_and_Suppliers_by_City-update": {
@@ -11819,17 +11768,6 @@
                     "example": 0
                 }
             },
-            "required": [
-                "CustomerName",
-                "Salesperson",
-                "OrderID",
-                "ShipperName",
-                "ProductID",
-                "ProductName",
-                "UnitPrice",
-                "Quantity",
-                "Discount"
-            ],
             "title": "Invoice (for create)"
         },
         "NorthwindModel.Invoice-update": {
@@ -12086,14 +12024,6 @@
                     "example": 0
                 }
             },
-            "required": [
-                "OrderID",
-                "ProductID",
-                "ProductName",
-                "UnitPrice",
-                "Quantity",
-                "Discount"
-            ],
             "title": "Order_Details_Extended (for create)"
         },
         "NorthwindModel.Order_Details_Extended-update": {
@@ -12156,9 +12086,6 @@
                     "example": 0
                 }
             },
-            "required": [
-                "OrderID"
-            ],
             "title": "Order_Subtotal (for create)"
         },
         "NorthwindModel.Order_Subtotal-update": {
@@ -12497,10 +12424,6 @@
                     "example": "string"
                 }
             },
-            "required": [
-                "OrderID",
-                "CompanyName"
-            ],
             "title": "Orders_Qry (for create)"
         },
         "NorthwindModel.Orders_Qry-update": {
@@ -12705,10 +12628,6 @@
                     "example": 0
                 }
             },
-            "required": [
-                "CategoryName",
-                "ProductName"
-            ],
             "title": "Product_Sales_for_1997 (for create)"
         },
         "NorthwindModel.Product_Sales_for_1997-update": {
@@ -12771,9 +12690,6 @@
                     "example": 0
                 }
             },
-            "required": [
-                "ProductName"
-            ],
             "title": "Products_Above_Average_Price (for create)"
         },
         "NorthwindModel.Products_Above_Average_Price-update": {
@@ -12856,11 +12772,6 @@
                     "type": "boolean"
                 }
             },
-            "required": [
-                "CategoryName",
-                "ProductName",
-                "Discontinued"
-            ],
             "title": "Products_by_Category (for create)"
         },
         "NorthwindModel.Products_by_Category-update": {
@@ -12942,11 +12853,6 @@
                     "example": 0
                 }
             },
-            "required": [
-                "CategoryID",
-                "CategoryName",
-                "ProductName"
-            ],
             "title": "Sales_by_Category (for create)"
         },
         "NorthwindModel.Sales_by_Category-update": {
@@ -13033,10 +12939,6 @@
                     "example": "2017-04-13T15:51:04Z"
                 }
             },
-            "required": [
-                "OrderID",
-                "CompanyName"
-            ],
             "title": "Sales_Totals_by_Amount (for create)"
         },
         "NorthwindModel.Sales_Totals_by_Amount-update": {
@@ -13123,9 +13025,6 @@
                     "example": 0
                 }
             },
-            "required": [
-                "OrderID"
-            ],
             "title": "Summary_of_Sales_by_Quarter (for create)"
         },
         "NorthwindModel.Summary_of_Sales_by_Quarter-update": {
@@ -13212,9 +13111,6 @@
                     "example": 0
                 }
             },
-            "required": [
-                "OrderID"
-            ],
             "title": "Summary_of_Sales_by_Year (for create)"
         },
         "NorthwindModel.Summary_of_Sales_by_Year-update": {

--- a/tools/tests/annotations-v2.openapi3.json
+++ b/tools/tests/annotations-v2.openapi3.json
@@ -694,9 +694,6 @@
                         "example": "Hello World"
                     }
                 },
-                "required": [
-                    "ID"
-                ],
                 "title": "SinglePartKey (for create)"
             },
             "Supported.Annotations.SinglePartKey-update": {
@@ -766,9 +763,6 @@
                         "example": "/Date(1492098664000)/"
                     }
                 },
-                "required": [
-                    "ID"
-                ],
                 "title": "PlainDateTimeKey (for create)"
             },
             "Supported.Annotations.PlainDateTimeKey-update": {

--- a/tools/tests/annotations-v2.swagger.json
+++ b/tools/tests/annotations-v2.swagger.json
@@ -663,9 +663,6 @@
                     "example": "Hello World"
                 }
             },
-            "required": [
-                "ID"
-            ],
             "title": "SinglePartKey (for create)"
         },
         "Supported.Annotations.SinglePartKey-update": {
@@ -747,9 +744,6 @@
                     "example": "/Date(1492098664000)/"
                 }
             },
-            "required": [
-                "ID"
-            ],
             "title": "PlainDateTimeKey (for create)"
         },
         "Supported.Annotations.PlainDateTimeKey-update": {

--- a/tools/tests/annotations.openapi3.json
+++ b/tools/tests/annotations.openapi3.json
@@ -3134,7 +3134,6 @@
                     }
                 },
                 "required": [
-                    "ID",
                     "PatternExt",
                     "AllowedValuesExt"
                 ],
@@ -3318,10 +3317,6 @@
                         "example": "15:51:04"
                     }
                 },
-                "required": [
-                    "One",
-                    "Two"
-                ],
                 "title": "TwoPartKey (for create)"
             },
             "Supported.Annotations.TwoPartKey-update": {

--- a/tools/tests/annotations.swagger.json
+++ b/tools/tests/annotations.swagger.json
@@ -2783,7 +2783,6 @@
                 }
             },
             "required": [
-                "ID",
                 "PatternExt",
                 "AllowedValuesExt"
             ],
@@ -2970,10 +2969,6 @@
                     "example": "15:51:04"
                 }
             },
-            "required": [
-                "One",
-                "Two"
-            ],
             "title": "TwoPartKey (for create)"
         },
         "Supported.Annotations.TwoPartKey-update": {

--- a/tools/tests/authorization.openapi3.json
+++ b/tools/tests/authorization.openapi3.json
@@ -304,9 +304,6 @@
                         "nullable": true
                     }
                 },
-                "required": [
-                    "ID"
-                ],
                 "title": "Person (for create)"
             },
             "auth.example.Person-update": {

--- a/tools/tests/authorization.swagger.json
+++ b/tools/tests/authorization.swagger.json
@@ -285,9 +285,6 @@
                     "example": "string"
                 }
             },
-            "required": [
-                "ID"
-            ],
             "title": "Person (for create)"
         },
         "auth.example.Person-update": {

--- a/tools/tests/containment.openapi3.json
+++ b/tools/tests/containment.openapi3.json
@@ -5079,9 +5079,6 @@
                         }
                     }
                 },
-                "required": [
-                    "ID"
-                ],
                 "title": "Whole (for create)"
             },
             "Containment.Whole-update": {
@@ -5164,9 +5161,6 @@
                         }
                     }
                 },
-                "required": [
-                    "index"
-                ],
                 "title": "Part (for create)"
             },
             "Containment.Part-update": {
@@ -5199,10 +5193,6 @@
                         "format": "int32"
                     }
                 },
-                "required": [
-                    "One",
-                    "Two"
-                ],
                 "title": "SubPart (for create)"
             },
             "Containment.SubPart-update": {
@@ -5245,9 +5235,6 @@
                         }
                     }
                 },
-                "required": [
-                    "Name"
-                ],
                 "title": "Folder (for create)"
             },
             "Containment.Folder-update": {

--- a/tools/tests/containment.swagger.json
+++ b/tools/tests/containment.swagger.json
@@ -4377,9 +4377,6 @@
                     }
                 }
             },
-            "required": [
-                "ID"
-            ],
             "title": "Whole (for create)"
         },
         "Containment.Whole-update": {
@@ -4455,9 +4452,6 @@
                     }
                 }
             },
-            "required": [
-                "index"
-            ],
             "title": "Part (for create)"
         },
         "Containment.Part-update": {
@@ -4490,10 +4484,6 @@
                     "format": "int32"
                 }
             },
-            "required": [
-                "One",
-                "Two"
-            ],
             "title": "SubPart (for create)"
         },
         "Containment.SubPart-update": {
@@ -4542,9 +4532,6 @@
                     }
                 }
             },
-            "required": [
-                "Name"
-            ],
             "title": "Folder (for create)"
         },
         "Containment.Folder-update": {

--- a/tools/tests/csdl-16.1.openapi3.json
+++ b/tools/tests/csdl-16.1.openapi3.json
@@ -2043,9 +2043,6 @@
                         ]
                     }
                 },
-                "required": [
-                    "ID"
-                ],
                 "title": "Product (for create)"
             },
             "ODataDemo.Product-update": {
@@ -2130,9 +2127,6 @@
                         }
                     }
                 },
-                "required": [
-                    "ID"
-                ],
                 "title": "Category (for create)"
             },
             "ODataDemo.Category-update": {
@@ -2194,9 +2188,6 @@
                         }
                     }
                 },
-                "required": [
-                    "ID"
-                ],
                 "title": "Supplier (for create)"
             },
             "ODataDemo.Supplier-update": {
@@ -2242,9 +2233,6 @@
                         "nullable": true
                     }
                 },
-                "required": [
-                    "Code"
-                ],
                 "title": "Country (for create)"
             },
             "ODataDemo.Country-update": {

--- a/tools/tests/csdl-16.1.swagger.json
+++ b/tools/tests/csdl-16.1.swagger.json
@@ -1796,9 +1796,6 @@
                     "$ref": "#/definitions/ODataDemo.Supplier-create"
                 }
             },
-            "required": [
-                "ID"
-            ],
             "title": "Product (for create)"
         },
         "ODataDemo.Product-update": {
@@ -1891,9 +1888,6 @@
                     }
                 }
             },
-            "required": [
-                "ID"
-            ],
             "title": "Category (for create)"
         },
         "ODataDemo.Category-update": {
@@ -1961,9 +1955,6 @@
                     }
                 }
             },
-            "required": [
-                "ID"
-            ],
             "title": "Supplier (for create)"
         },
         "ODataDemo.Supplier-update": {
@@ -2018,9 +2009,6 @@
                     "example": "string"
                 }
             },
-            "required": [
-                "Code"
-            ],
             "title": "Country (for create)"
         },
         "ODataDemo.Country-update": {

--- a/tools/tests/descriptions.openapi3.json
+++ b/tools/tests/descriptions.openapi3.json
@@ -3082,9 +3082,6 @@
                         }
                     }
                 },
-                "required": [
-                    "id"
-                ],
                 "title": "Entity Type - Description (for create)",
                 "description": "Entity Type - LongDescription"
             },
@@ -3111,9 +3108,6 @@
                         "maxLength": 70
                     }
                 },
-                "required": [
-                    "id"
-                ],
                 "title": "subEntity (for create)"
             },
             "descriptions.subEntity-update": {

--- a/tools/tests/descriptions.swagger.json
+++ b/tools/tests/descriptions.swagger.json
@@ -2707,9 +2707,6 @@
                     }
                 }
             },
-            "required": [
-                "id"
-            ],
             "title": "Entity Type - Description (for create)",
             "description": "Entity Type - LongDescription"
         },
@@ -2736,9 +2733,6 @@
                     "maxLength": 70
                 }
             },
-            "required": [
-                "id"
-            ],
             "title": "subEntity (for create)"
         },
         "descriptions.subEntity-update": {

--- a/tools/tests/keys-v4.01.openapi3.json
+++ b/tools/tests/keys-v4.01.openapi3.json
@@ -364,12 +364,6 @@
                         "example": "P4DT15H51M04S"
                     }
                 },
-                "required": [
-                    "int32",
-                    "timeOfDay",
-                    "boolean",
-                    "duration"
-                ],
                 "title": "MultiPartKey (for create)"
             },
             "KeyTypes.MultiPartKey-update": {

--- a/tools/tests/keys-v4.01.swagger.json
+++ b/tools/tests/keys-v4.01.swagger.json
@@ -329,12 +329,6 @@
                     "example": "P4DT15H51M04S"
                 }
             },
-            "required": [
-                "int32",
-                "timeOfDay",
-                "boolean",
-                "duration"
-            ],
             "title": "MultiPartKey (for create)"
         },
         "KeyTypes.MultiPartKey-update": {

--- a/tools/tests/keys-v4.openapi3.json
+++ b/tools/tests/keys-v4.openapi3.json
@@ -364,12 +364,6 @@
                         "example": "P4DT15H51M04S"
                     }
                 },
-                "required": [
-                    "int32",
-                    "timeOfDay",
-                    "boolean",
-                    "duration"
-                ],
                 "title": "MultiPartKey (for create)"
             },
             "KeyTypes.MultiPartKey-update": {

--- a/tools/tests/keys-v4.swagger.json
+++ b/tools/tests/keys-v4.swagger.json
@@ -329,12 +329,6 @@
                     "example": "P4DT15H51M04S"
                 }
             },
-            "required": [
-                "int32",
-                "timeOfDay",
-                "boolean",
-                "duration"
-            ],
             "title": "MultiPartKey (for create)"
         },
         "KeyTypes.MultiPartKey-update": {

--- a/tools/tests/media-entities-v2.openapi3.json
+++ b/tools/tests/media-entities-v2.openapi3.json
@@ -346,9 +346,6 @@
                         "format": "int32"
                     }
                 },
-                "required": [
-                    "ID"
-                ],
                 "title": "MediaType (for create)"
             },
             "Media.Entities.MediaType-update": {

--- a/tools/tests/media-entities-v2.swagger.json
+++ b/tools/tests/media-entities-v2.swagger.json
@@ -319,9 +319,6 @@
                     "format": "int32"
                 }
             },
-            "required": [
-                "ID"
-            ],
             "title": "MediaType (for create)"
         },
         "Media.Entities.MediaType-update": {

--- a/tools/tests/odata-rw-v2.openapi3.json
+++ b/tools/tests/odata-rw-v2.openapi3.json
@@ -1591,9 +1591,6 @@
                         ]
                     }
                 },
-                "required": [
-                    "ID"
-                ],
                 "title": "Product (for create)"
             },
             "ODataDemo.Product-update": {
@@ -1677,9 +1674,6 @@
                         }
                     }
                 },
-                "required": [
-                    "ID"
-                ],
                 "title": "Category (for create)"
             },
             "ODataDemo.Category-update": {
@@ -1754,9 +1748,6 @@
                         }
                     }
                 },
-                "required": [
-                    "ID"
-                ],
                 "title": "Supplier (for create)"
             },
             "ODataDemo.Supplier-update": {

--- a/tools/tests/odata-rw-v2.swagger.json
+++ b/tools/tests/odata-rw-v2.swagger.json
@@ -1420,9 +1420,6 @@
                     "$ref": "#/definitions/ODataDemo.Supplier-create"
                 }
             },
-            "required": [
-                "ID"
-            ],
             "title": "Product (for create)"
         },
         "ODataDemo.Product-update": {
@@ -1520,9 +1517,6 @@
                     }
                 }
             },
-            "required": [
-                "ID"
-            ],
             "title": "Category (for create)"
         },
         "ODataDemo.Category-update": {
@@ -1606,9 +1600,6 @@
                     }
                 }
             },
-            "required": [
-                "ID"
-            ],
             "title": "Supplier (for create)"
         },
         "ODataDemo.Supplier-update": {

--- a/tools/tests/odata-rw-v3.openapi3.json
+++ b/tools/tests/odata-rw-v3.openapi3.json
@@ -3111,9 +3111,6 @@
                         ]
                     }
                 },
-                "required": [
-                    "ID"
-                ],
                 "anyOf": [
                     {
                         "$ref": "#/components/schemas/ODataDemo.FeaturedProduct-create"
@@ -3317,9 +3314,6 @@
                         ]
                     }
                 },
-                "required": [
-                    "ID"
-                ],
                 "title": "FeaturedProduct (for create)"
             },
             "ODataDemo.FeaturedProduct-update": {
@@ -3405,9 +3399,6 @@
                         ]
                     }
                 },
-                "required": [
-                    "ProductID"
-                ],
                 "title": "ProductDetail (for create)"
             },
             "ODataDemo.ProductDetail-update": {
@@ -3458,9 +3449,6 @@
                         }
                     }
                 },
-                "required": [
-                    "ID"
-                ],
                 "title": "Category (for create)"
             },
             "ODataDemo.Category-update": {
@@ -3551,9 +3539,6 @@
                         }
                     }
                 },
-                "required": [
-                    "ID"
-                ],
                 "title": "Supplier (for create)"
             },
             "ODataDemo.Supplier-update": {
@@ -3715,9 +3700,6 @@
                         ]
                     }
                 },
-                "required": [
-                    "ID"
-                ],
                 "anyOf": [
                     {
                         "$ref": "#/components/schemas/ODataDemo.Customer-create"
@@ -3816,9 +3798,6 @@
                         "example": 0
                     }
                 },
-                "required": [
-                    "ID"
-                ],
                 "title": "Customer (for create)"
             },
             "ODataDemo.Customer-update": {
@@ -3944,9 +3923,6 @@
                         "example": 3.14
                     }
                 },
-                "required": [
-                    "ID"
-                ],
                 "title": "Employee (for create)"
             },
             "ODataDemo.Employee-update": {
@@ -4068,9 +4044,6 @@
                         ]
                     }
                 },
-                "required": [
-                    "PersonID"
-                ],
                 "title": "PersonDetail (for create)"
             },
             "ODataDemo.PersonDetail-update": {
@@ -4156,9 +4129,6 @@
                         ]
                     }
                 },
-                "required": [
-                    "ID"
-                ],
                 "title": "Advertisement (for create)"
             },
             "ODataDemo.Advertisement-update": {

--- a/tools/tests/odata-rw-v3.swagger.json
+++ b/tools/tests/odata-rw-v3.swagger.json
@@ -2703,9 +2703,6 @@
                     "$ref": "#/definitions/ODataDemo.ProductDetail-create"
                 }
             },
-            "required": [
-                "ID"
-            ],
             "title": "Product (for create)"
         },
         "ODataDemo.Product-update": {
@@ -2879,9 +2876,6 @@
                     "$ref": "#/definitions/ODataDemo.Advertisement-create"
                 }
             },
-            "required": [
-                "ID"
-            ],
             "title": "FeaturedProduct (for create)"
         },
         "ODataDemo.FeaturedProduct-update": {
@@ -2967,9 +2961,6 @@
                     "$ref": "#/definitions/ODataDemo.Product-create"
                 }
             },
-            "required": [
-                "ProductID"
-            ],
             "title": "ProductDetail (for create)"
         },
         "ODataDemo.ProductDetail-update": {
@@ -3029,9 +3020,6 @@
                     }
                 }
             },
-            "required": [
-                "ID"
-            ],
             "title": "Category (for create)"
         },
         "ODataDemo.Category-update": {
@@ -3111,9 +3099,6 @@
                     }
                 }
             },
-            "required": [
-                "ID"
-            ],
             "title": "Supplier (for create)"
         },
         "ODataDemo.Supplier-update": {
@@ -3300,9 +3285,6 @@
                     "$ref": "#/definitions/ODataDemo.PersonDetail-create"
                 }
             },
-            "required": [
-                "ID"
-            ],
             "title": "Person (for create)"
         },
         "ODataDemo.Person-update": {
@@ -3374,9 +3356,6 @@
                     "example": 0
                 }
             },
-            "required": [
-                "ID"
-            ],
             "title": "Customer (for create)"
         },
         "ODataDemo.Customer-update": {
@@ -3481,9 +3460,6 @@
                     "example": 3.14
                 }
             },
-            "required": [
-                "ID"
-            ],
             "title": "Employee (for create)"
         },
         "ODataDemo.Employee-update": {
@@ -3586,9 +3562,6 @@
                     "$ref": "#/definitions/ODataDemo.Person-create"
                 }
             },
-            "required": [
-                "PersonID"
-            ],
             "title": "PersonDetail (for create)"
         },
         "ODataDemo.PersonDetail-update": {
@@ -3668,9 +3641,6 @@
                     "$ref": "#/definitions/ODataDemo.FeaturedProduct-create"
                 }
             },
-            "required": [
-                "ID"
-            ],
             "title": "Advertisement (for create)"
         },
         "ODataDemo.Advertisement-update": {


### PR DESCRIPTION
Currently, non-computed key properties are required in OpenAPI. But this ignores the (90%) case of key properties that can be either provided or omitted (in which case they are computed by the server).

We have three cases of key properties
Annotation of key property|Meaning for create request|contained in OpenAPI `-create` schema|required
---|---|---|---
`Common.FieldControl = Mandatory`|Must be provided, validated by server|yes|yes
`Core.Computed`|Must not be provided, computed by server|no|no
Neither|May be provided|yes|no
