### PR TITLE
TopSupported and SkipSupported non-nullable with DefaultValue="true"

### DIFF
--- a/tools/V4-CSDL-to-OpenAPI.xsl
+++ b/tools/V4-CSDL-to-OpenAPI.xsl
@@ -4270,13 +4270,13 @@
     <xsl:variable name="target-topSupported" select="$target-topSupported-p/@Bool|$target-topSupported-p/edm:Bool" />
     <xsl:variable name="navigation-topSupported-p" select="$navigationPropertyRestriction/edm:PropertyValue[@Property='TopSupported']" />
     <xsl:variable name="navigation-topSupported" select="$navigation-topSupported-p/@Bool|$navigation-topSupported-p/edm:Bool" />
-    <xsl:variable name="with-top" select="not($navigation-topSupported='false' or (not($navigation-topSupported) and $target-topSupported='false'))" />
+    <xsl:variable name="with-top" select="not($navigation-topSupported='false' or (not($navigationPropertyRestriction) and $target-topSupported='false'))" />
 
     <xsl:variable name="target-skipSupported-p" select="$target-annotations[@Term=$capabilitiesSkipSupported or @Term=$capabilitiesSkipSupportedAliased]" />
     <xsl:variable name="target-skipSupported" select="$target-skipSupported-p/@Bool|$target-skipSupported-p/edm:Bool" />
     <xsl:variable name="navigation-skipSupported-p" select="$navigationPropertyRestriction/edm:PropertyValue[@Property='SkipSupported']" />
     <xsl:variable name="navigation-skipSupported" select="$navigation-skipSupported-p/@Bool|$navigation-skipSupported-p/edm:Bool" />
-    <xsl:variable name="with-skip" select="not($navigation-skipSupported='false' or (not($navigation-skipSupported) and $target-skipSupported='false'))" />
+    <xsl:variable name="with-skip" select="not($navigation-skipSupported='false' or (not($navigationPropertyRestriction) and $target-skipSupported='false'))" />
 
     <xsl:variable name="target-searchable-p" select="$target-annotations[@Term=$capabilitiesSearchRestrictions or @Term=$capabilitiesSearchRestrictionsAliased]/edm:Record/edm:PropertyValue[@Property='Searchable']" />
     <xsl:variable name="target-searchable" select="$target-searchable-p/@Bool|$target-searchable-p/edm:Bool" />

--- a/tools/tests/addressable-v2.openapi3.json
+++ b/tools/tests/addressable-v2.openapi3.json
@@ -255,6 +255,12 @@
                 ],
                 "parameters": [
                     {
+                        "$ref": "#/components/parameters/top"
+                    },
+                    {
+                        "$ref": "#/components/parameters/skip"
+                    },
+                    {
                         "name": "$filter",
                         "in": "query",
                         "description": "Filter items by property values, see [Filtering](https://help.sap.com/doc/5890d27be418427993fafa6722cdc03b/Cloud/en-US/OdataV2.pdf#page=64)",

--- a/tools/tests/addressable-v2.swagger.json
+++ b/tools/tests/addressable-v2.swagger.json
@@ -228,6 +228,12 @@
                 ],
                 "parameters": [
                     {
+                        "$ref": "#/parameters/top"
+                    },
+                    {
+                        "$ref": "#/parameters/skip"
+                    },
+                    {
                         "name": "$filter",
                         "in": "query",
                         "description": "Filter items by property values, see [Filtering](https://help.sap.com/doc/5890d27be418427993fafa6722cdc03b/Cloud/en-US/OdataV2.pdf#page=64)",

--- a/tools/tests/annotations.openapi3.json
+++ b/tools/tests/annotations.openapi3.json
@@ -1981,7 +1981,14 @@
                     "ReadOnlySingleton",
                     "TwoReadOnlySet"
                 ],
-                "parameters": [],
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/top"
+                    },
+                    {
+                        "$ref": "#/components/parameters/skip"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "Retrieved entities",

--- a/tools/tests/annotations.swagger.json
+++ b/tools/tests/annotations.swagger.json
@@ -1749,7 +1749,14 @@
                     "ReadOnlySingleton",
                     "TwoReadOnlySet"
                 ],
-                "parameters": [],
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/top"
+                    },
+                    {
+                        "$ref": "#/parameters/skip"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "Retrieved entities",


### PR DESCRIPTION
Fixes #322 

Assume an entity set of singleton $S$ with a non-contained navigation property $p$ and a navigation property binding of $S/p$ to the entity set or singleton $T$.

If $S$ is annotated with `Capabilities.NavigationRestrictions/RestrictedProperties` annotation with `NavigationProperty`${}=p$ but without `TopSupported`, the default value `TopSupported=true` is implied and hence the resource path $S/p$ supports `$top`, regardless of any annotation `Capabilities.TopSupported` on $T$. Analogous for `SkipSupported`.

The `V4-CSDL-to-OpenAPI.xsl` tool currently behaves differently: In the absence of `Capabilities.NavigationRestrictions/RestrictedProperties/TopSupported` on $S$ it evaluates `Capabilities.TopSupported` on $T$, ignoring the default value.